### PR TITLE
Add `StringOfLength` assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following set of extra asserts are provided by this package:
 - [NullOrString](#nullorstring)
 - [Phone](#phone) (requires `google-libphonenumber`)
 - [PlainObject](#plainobject)
+- [StringOfLength](#stringoflength)
 - [TaxpayerIdentificationNumber](#taxpayeridentificationnumber) (_TIN_, requires `tin-validator`)
 - [UkModulusChecking](#ukmoduluschecking) (requires `uk-modulus-checking`)
 - [Uri](#uri) (requires `urijs`)
@@ -197,6 +198,13 @@ Tests if the phone is valid and optionally if it belongs to the given country. T
 
 ### PlainObject
 Tests if the value is a plain object.
+
+### StringOfLength
+Tests if the value is a string within the given boundaries.
+
+#### Arguments
+- `max` (optional) - the maximum number of characters.
+- `min` (optional) - the minimum number of characters (defaults to 1, to avoid empty strings).
 
 ### TaxpayerIdentificationNumber
 Tests if the value is a valid Taxpayer Identification Number (_TIN_) as defined by the [U.S. IRS](http://www.irs.gov/Individuals/International-Taxpayers/Taxpayer-Identification-Numbers-TIN).

--- a/src/asserts/string-of-length-assert.js
+++ b/src/asserts/string-of-length-assert.js
@@ -1,0 +1,28 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { Assert as is } from 'validator.js';
+
+/**
+ * Exports `StringOfLengthAssert`.
+ */
+
+export default function stringOfLengthAssert({ max, min = 1 } = {}) {
+  this.max = max;
+  this.min = min;
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = value => {
+    is.string().validate(value);
+    is.ofLength({ max: this.max, min: this.min }).validate(value);
+
+    return true;
+  };
+
+  return this;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ import NullOrDate from './asserts/null-or-date-assert.js';
 import NullOrString from './asserts/null-or-string-assert.js';
 import Phone from './asserts/phone-assert.js';
 import PlainObject from './asserts/plain-object-assert.js';
+import StringOfLength from './asserts/string-of-length-assert.js';
 import TaxpayerIdentificationNumber from './asserts/taxpayer-identification-number-assert.js';
 import UkModulusChecking from './asserts/uk-modulus-checking-assert.js';
 import Uri from './asserts/uri-assert.js';
@@ -71,6 +72,7 @@ export default {
   NullOrString,
   Phone,
   PlainObject,
+  StringOfLength,
   TaxpayerIdentificationNumber,
   UkModulusChecking,
   Uri,

--- a/test/asserts/string-of-length-assert_test.js
+++ b/test/asserts/string-of-length-assert_test.js
@@ -1,0 +1,72 @@
+
+/**
+ * Module dependencies.
+ */
+
+import StringOfLengthAssert from '../../src/asserts/string-of-length-assert';
+import should from 'should';
+import { Assert as BaseAssert, Violation } from 'validator.js';
+
+/**
+ * Extend `Assert` with `StringOfLengthAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  StringOfLength: StringOfLengthAssert
+});
+
+/**
+ * Test `StringOfLengthAssert`,
+ */
+
+describe('StringOfLengthAssert', () => {
+  it('should throw an error if the input value is not a string', () => {
+    [{}, []].forEach(choice => {
+      try {
+        new Assert().StringOfLength().validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        e.violation.value.should.equal('must_be_a_string');
+      }
+    });
+  });
+
+  it('should throw an error if the input value is empty', () => {
+    try {
+      new Assert().StringOfLength().validate('');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().should.have.properties({ assert: 'Length', violation: { min: 1 } });
+    }
+  });
+
+  it('should throw an error if the input value is longer than the maximum length', () => {
+    try {
+      new Assert().StringOfLength({ max: 2 }).validate('foo');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().should.have.properties({ assert: 'Length', violation: { max: 2 } });
+    }
+  });
+
+  it('should throw an error if the input value is shorter than the minimum length', () => {
+    try {
+      new Assert().StringOfLength({ min: 4 }).validate('foo');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().should.have.properties({ assert: 'Length', violation: { min: 4 } });
+    }
+  });
+
+  it('should accept a string within the length boundaries', () => {
+    new Assert().StringOfLength({ max: 4, min: 2 }).validate('foo');
+  });
+});

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -40,6 +40,7 @@ describe('validator.js-asserts', () => {
       'NullOrString',
       'Phone',
       'PlainObject',
+      'StringOfLength',
       'TaxpayerIdentificationNumber',
       'UkModulusChecking',
       'Uri',


### PR DESCRIPTION
This is a nice little assert that allows us to replace the repeated:

```js
validate(foo, {
  foo: [is.string(), is.ofLength({ max, min })]
});

// or

validate(foo, {
  foo: [is.notBlank(), is.ofLength({ max, min })]
});
```

with the simpler alternative:

```js
validate(foo, {
  foo: is.stringOfLength({ max, min })
});
```

Since the vast majority of strings need to be validated for size anyway, this helps us avoid duplication for an extremely recurring pattern.

`NullOrString` also accepts `max` and `min`, but allows `null` values, so we can't always use it. `Length` is also not enough, because it accepts other objects that respond to `length`, such as arrays. `String` doesn't allow us to specify length boundaries. Hence the need for a new assert.