### PR TITLE
Fix mixed content issue preventing page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <title>validator.js-asserts</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src="https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js"></script>
   <script src="https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js"></script>
 


### PR DESCRIPTION
This PR updates the URL for the `<script>` tag that imports `jQuery` changing the protocol from HTTP to HTTPs. This issue is currently preventing the `Flatdoc` from loading.