### PR TITLE
Support bignumber.js@7+ and add optional `validateSignificantDigits` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.7.2",
-    "bignumber.js": "^2.3.0",
+    "bignumber.js": "^8.0.2",
     "creditcard": "^0.1.2",
     "eslint": "^2.8.0",
     "eslint-config-seegno": "^4.0.0",
@@ -77,7 +77,7 @@
   },
   "optionalPeerDependencies": {
     "abavalidator": ">=2 <3",
-    "bignumber.js": ">=2 <3",
+    "bignumber.js": ">=7 <9",
     "creditcard": ">=0.0.1 <1.0.0",
     "google-libphonenumber": ">=1 <4",
     "iban": ">=0.0.6 <1.0.0",

--- a/src/asserts/big-number-assert.js
+++ b/src/asserts/big-number-assert.js
@@ -9,12 +9,14 @@ import { Violation } from 'validator.js';
  * Export `BigNumberAssert`.
  */
 
-export default function bigNumberAssert() {
+export default function bigNumberAssert({ validateSignificantDigits = true } = {}) {
   /**
    * Optional peer dependencies.
    */
 
   const BigNumber = require('bignumber.js');
+
+  BigNumber.DEBUG = !!validateSignificantDigits;
 
   /**
    * Class name.
@@ -28,8 +30,16 @@ export default function bigNumberAssert() {
 
   this.validate = value => {
     try {
-      new BigNumber(value); // eslint-disable-line no-new
+      const number = new BigNumber(value);
+
+      if (Number.isNaN(number.toNumber())) {
+        throw new Error(`[BigNumber Error] Not a number: ${value.toString()}`);
+      }
     } catch (e) {
+      if (e.message.startsWith('[BigNumber Error]')) {
+        throw new Violation(this, value, { message: e.message });
+      }
+
       throw new Violation(this, value);
     }
 

--- a/src/asserts/big-number-equal-to-assert.js
+++ b/src/asserts/big-number-equal-to-assert.js
@@ -3,18 +3,27 @@
  * Module dependencies.
  */
 
-import { Violation } from 'validator.js';
+import BigNumberAssert from './big-number-assert';
+import { Assert as BaseAssert, Violation } from 'validator.js';
 
 /**
  * Export `BigNumberEqualToAssert`.
  */
 
-export default function bigNumberEqualToAssert(value) {
+export default function bigNumberEqualToAssert(value, { validateSignificantDigits = true } = {}) {
   /**
    * Optional peer dependencies.
    */
 
   const BigNumber = require('bignumber.js');
+
+  BigNumber.DEBUG = !!validateSignificantDigits;
+
+  /**
+   * Extend `Assert` with `BigNumberAssert`.
+   */
+
+  const Assert = BaseAssert.extend({ BigNumber: BigNumberAssert });
 
   /**
    * Class name.
@@ -26,6 +35,8 @@ export default function bigNumberEqualToAssert(value) {
     throw new Error('A value is required.');
   }
 
+  new Assert().BigNumber({ validateSignificantDigits }).validate(value);
+
   this.value = new BigNumber(value);
 
   /**
@@ -33,16 +44,18 @@ export default function bigNumberEqualToAssert(value) {
    */
 
   this.validate = value => {
+    new Assert().BigNumber({ validateSignificantDigits }).validate(value);
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.equals(this.value)) {
+      if (!number.isEqualTo(this.value)) {
         throw new Error();
       }
     } catch (e) {
       const context = { value: this.value.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/src/asserts/big-number-greater-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-greater-than-or-equal-to-assert.js
@@ -3,18 +3,27 @@
  * Module dependencies.
  */
 
-import { Violation } from 'validator.js';
+import BigNumberAssert from './big-number-assert';
+import { Assert as BaseAssert, Violation } from 'validator.js';
 
 /**
  * Export `BigNumberGreaterThanOrEqualToAssert`.
  */
 
-export default function bigNumberGreaterThanOrEqualToAssert(threshold) {
+export default function bigNumberGreaterThanOrEqualToAssert(threshold, { validateSignificantDigits = true } = {}) {
   /**
    * Optional peer dependencies.
    */
 
   const BigNumber = require('bignumber.js');
+
+  BigNumber.DEBUG = !!validateSignificantDigits;
+
+  /**
+   * Extend `Assert` with `BigNumberAssert`.
+   */
+
+  const Assert = BaseAssert.extend({ BigNumber: BigNumberAssert });
 
   /**
    * Class name.
@@ -26,6 +35,8 @@ export default function bigNumberGreaterThanOrEqualToAssert(threshold) {
     throw new Error('A threshold value is required.');
   }
 
+  new Assert().BigNumber({ validateSignificantDigits }).validate(threshold);
+
   this.threshold = new BigNumber(threshold);
 
   /**
@@ -33,16 +44,18 @@ export default function bigNumberGreaterThanOrEqualToAssert(threshold) {
    */
 
   this.validate = value => {
+    new Assert().BigNumber({ validateSignificantDigits }).validate(value);
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.greaterThanOrEqualTo(this.threshold)) {
+      if (!number.isGreaterThanOrEqualTo(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/src/asserts/big-number-less-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-less-than-or-equal-to-assert.js
@@ -3,18 +3,28 @@
  * Module dependencies.
  */
 
-import { Violation } from 'validator.js';
+import BigNumberAssert from './big-number-assert';
+import { Assert as BaseAssert, Violation } from 'validator.js';
+
 
 /**
  * Export `BigNumberLessThanOrEqualToAssert`.
  */
 
-export default function bigNumberLessThanOrEqualToAssert(threshold) {
+export default function bigNumberLessThanOrEqualToAssert(threshold, { validateSignificantDigits = true } = {}) {
   /**
    * Optional peer dependencies.
    */
 
   const BigNumber = require('bignumber.js');
+
+  BigNumber.DEBUG = !!validateSignificantDigits;
+
+  /**
+   * Extend `Assert` with `BigNumberAssert`.
+   */
+
+  const Assert = BaseAssert.extend({ BigNumber: BigNumberAssert });
 
   /**
    * Class name.
@@ -26,6 +36,8 @@ export default function bigNumberLessThanOrEqualToAssert(threshold) {
     throw new Error('A threshold value is required.');
   }
 
+  new Assert().BigNumber({ validateSignificantDigits }).validate(threshold);
+
   this.threshold = new BigNumber(threshold);
 
   /**
@@ -33,16 +45,18 @@ export default function bigNumberLessThanOrEqualToAssert(threshold) {
    */
 
   this.validate = value => {
+    new Assert().BigNumber({ validateSignificantDigits }).validate(value);
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.lessThanOrEqualTo(this.threshold)) {
+      if (!number.isLessThanOrEqualTo(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/test/asserts/big-number-assert_test.js
+++ b/test/asserts/big-number-assert_test.js
@@ -20,31 +20,71 @@ const Assert = BaseAssert.extend({
  */
 
 describe('BigNumberAssert', () => {
-  it('should throw an error if the input value is not a big number', () => {
-    const choices = [[], {}, ''];
+  [undefined, { validateSignificantDigits: true }, { validateSignificantDigits: false }].forEach(option => {
+    describe(`with option '${option ? `{ validateSignificantDigits: ${option.validateSignificantDigits} }` : undefined }'`, () => {
+      it('should throw an error if the input value is not a big number', () => {
+        const choices = [[], {}, ''];
 
-    choices.forEach(choice => {
-      try {
-        new Assert().BigNumber().validate(choice);
+        choices.forEach(choice => {
+          try {
+            new Assert().BigNumber(option).validate(choice);
 
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(Violation);
+            should.fail();
+          } catch (e) {
+            e.should.be.instanceOf(Violation);
+          }
+        });
+      });
+
+      it('should expose `assert` equal to `BigNumber`', () => {
+        try {
+          new Assert().BigNumber(option).validate();
+
+          should.fail();
+        } catch (e) {
+          e.show().assert.should.equal('BigNumber');
+        }
+      });
+
+      it('should accept a big number', () => {
+        const choices = [
+          1.01,
+          1.0111111111,
+          '1.0111111111'
+        ];
+
+        choices.forEach(choice => {
+          new Assert().BigNumber(option).validate(choice);
+        });
+      });
+
+      if (!option || option.validateSignificantDigits === true) {
+        it('should throw an error if a number has more than 15 significant digits', () => {
+          try {
+            new Assert().BigNumber(option).validate(1.011111111111111111111111111111111111111111);
+
+            should.fail();
+          } catch (e) {
+            e.should.be.instanceOf(Violation);
+            e.show().assert.should.equal('BigNumber');
+            e.show().violation.message.should.equal('[BigNumber Error] Number primitive has more than 15 significant digits: 1.011111111111111');
+          }
+        });
+      } else {
+        it('should accept a big number with more than 15 significant digits', () => {
+          const choices = [
+            1.01,
+            1.0111111111,
+            1.011111111111111111111111111111111111111111,
+            '1.0111111111',
+            '1.011111111111111111111111111111111111111111'
+          ];
+
+          choices.forEach(choice => {
+            new Assert().BigNumber({ validateSignificantDigits: false }).validate(choice);
+          });
+        });
       }
     });
-  });
-
-  it('should expose `assert` equal to `BigNumber`', () => {
-    try {
-      new Assert().BigNumber().validate();
-
-      should.fail();
-    } catch (e) {
-      e.show().assert.should.equal('BigNumber');
-    }
-  });
-
-  it('should accept a big number', () => {
-    new Assert().BigNumber().validate(1.01);
   });
 });

--- a/test/asserts/big-number-equal-to-assert_test.js
+++ b/test/asserts/big-number-equal-to-assert_test.js
@@ -31,85 +31,90 @@ describe('BigNumberEqualToAssert', () => {
     }
   });
 
-  it('should throw an error if `value` is not a number', () => {
-    try {
-      new Assert().BigNumberEqualTo({});
+  [undefined, { validateSignificantDigits: true }, { validateSignificantDigits: false }].forEach(option => {
+    describe(`with option '${option ? `{ validateSignificantDigits: ${option.validateSignificantDigits} }` : undefined }'`, () => {
+      it('should throw an error if `value` is not a number', () => {
+        try {
+          new Assert().BigNumberEqualTo({}, option);
 
-      should.fail();
-    } catch (e) {
-      e.message.should.match(/not a number/);
-    }
-  });
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
 
-  it('should throw an error if the input value is not a number', () => {
-    const choices = [[], {}, ''];
+      it('should throw an error if the input value is not a number', () => {
+        const choices = [[], {}, ''];
 
-    choices.forEach(choice => {
-      try {
-        new Assert().BigNumberEqualTo(10).validate(choice);
+        choices.forEach(choice => {
+          try {
+            new Assert().BigNumberEqualTo(10, option).validate(choice);
 
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(Violation);
-      }
+            should.fail();
+          } catch (e) {
+            e.should.be.instanceOf(Violation);
+          }
+        });
+      });
+
+      it('should throw an error if the input number is greater than the value', () => {
+        try {
+          new Assert().BigNumberEqualTo(10, option).validate(12);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should throw an error if the input number is less than the value', () => {
+        try {
+          new Assert().BigNumberEqualTo(10, option).validate(9);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should expose `assert` equal to `BigNumberEqualTo`', () => {
+        try {
+          new Assert().BigNumberEqualTo(1, option).validate(0.1);
+
+          should.fail();
+        } catch (e) {
+          e.show().assert.should.equal('BigNumberEqualTo');
+        }
+      });
+
+      it('should expose `message` on the violation if the input value is not a number', () => {
+        try {
+          new Assert().BigNumberEqualTo(10, option).validate({});
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
+
+      it('should expose `value` on the violation', () => {
+        try {
+          new Assert().BigNumberEqualTo(10, option).validate(0.1);
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.value.should.equal('10');
+        }
+      });
+
+      it('should accept a big number as a value', () => {
+        new Assert().BigNumberEqualTo(new BigNumber(10), option).validate(10);
+      });
+
+      it('should accept a number that is equal to value', () => {
+        new Assert().BigNumberEqualTo(10, option).validate(10);
+      });
     });
-  });
-
-  it('should throw an error if the input number is greater than the value', () => {
-    try {
-      new Assert().BigNumberEqualTo(10).validate(12);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should throw an error if the input number is less than the value', () => {
-    try {
-      new Assert().BigNumberEqualTo(10).validate(9);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should expose `assert` equal to `BigNumberEqualTo`', () => {
-    try {
-      new Assert().BigNumberEqualTo(1).validate(0.1);
-
-      should.fail();
-    } catch (e) {
-      e.show().assert.should.equal('BigNumberEqualTo');
-    }
-  });
-
-  it('should expose `message` on the violation if the input value is not a number', () => {
-    try {
-      new Assert().BigNumberEqualTo(10).validate({});
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
-    }
-  });
-
-  it('should expose `value` on the violation', () => {
-    try {
-      new Assert().BigNumberEqualTo(10).validate(0.1);
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.value.should.equal('10');
-    }
-  });
-
-  it('should accept a big number as a value', () => {
-    new Assert().BigNumberEqualTo(new BigNumber(10)).validate(10);
-  });
-
-  it('should accept a number that is equal to value', () => {
-    new Assert().BigNumberEqualTo(10).validate(10);
   });
 });

--- a/test/asserts/big-number-greater-than-assert_test.js
+++ b/test/asserts/big-number-greater-than-assert_test.js
@@ -31,85 +31,90 @@ describe('BigNumberGreaterThanAssert', () => {
     }
   });
 
-  it('should throw an error if `threshold` is not a number', () => {
-    try {
-      new Assert().BigNumberGreaterThan({});
+  [undefined, { validateSignificantDigits: true }, { validateSignificantDigits: false }].forEach(option => {
+    describe(`with option '${option ? `{ validateSignificantDigits: ${option.validateSignificantDigits} }` : undefined }'`, () => {
+      it('should throw an error if `threshold` is not a number', () => {
+        try {
+          new Assert().BigNumberGreaterThan({}, option);
 
-      should.fail();
-    } catch (e) {
-      e.message.should.match(/not a number/);
-    }
-  });
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
 
-  it('should throw an error if the input value is not a number', () => {
-    const choices = [[], {}, ''];
+      it('should throw an error if the input value is not a number', () => {
+        const choices = [[], {}, ''];
 
-    choices.forEach(choice => {
-      try {
-        new Assert().BigNumberGreaterThan(10).validate(choice);
+        choices.forEach(choice => {
+          try {
+            new Assert().BigNumberGreaterThan(10, option).validate(choice);
 
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(Violation);
-      }
+            should.fail();
+          } catch (e) {
+            e.should.be.instanceOf(Violation);
+          }
+        });
+      });
+
+      it('should throw an error if the input number is equal to threshold', () => {
+        try {
+          new Assert().BigNumberGreaterThan(10, option).validate(10);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should throw an error if the input number is less than the threshold', () => {
+        try {
+          new Assert().BigNumberGreaterThan(10, option).validate(9.99999999);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should expose `assert` equal to `BigNumberGreaterThan`', () => {
+        try {
+          new Assert().BigNumberGreaterThan(1, option).validate(0.1);
+
+          should.fail();
+        } catch (e) {
+          e.show().assert.should.equal('BigNumberGreaterThan');
+        }
+      });
+
+      it('should expose `message` on the violation if the input value is not a number', () => {
+        try {
+          new Assert().BigNumberGreaterThan(10, option).validate({});
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
+
+      it('should expose `threshold` on the violation', () => {
+        try {
+          new Assert().BigNumberGreaterThan(10, option).validate(0.1);
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.threshold.should.equal('10');
+        }
+      });
+
+      it('should accept a big number as a `threshold` value', () => {
+        new Assert().BigNumberGreaterThan(new BigNumber(10), option).validate(10.00000001);
+      });
+
+      it('should accept a number that is greater than threshold', () => {
+        new Assert().BigNumberGreaterThan(10, option).validate(10.00000001);
+      });
     });
-  });
-
-  it('should throw an error if the input number is equal to threshold', () => {
-    try {
-      new Assert().BigNumberGreaterThan(10).validate(10);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should throw an error if the input number is less than the threshold', () => {
-    try {
-      new Assert().BigNumberGreaterThan(10).validate(9.99999999);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should expose `assert` equal to `BigNumberGreaterThan`', () => {
-    try {
-      new Assert().BigNumberGreaterThan(1).validate(0.1);
-
-      should.fail();
-    } catch (e) {
-      e.show().assert.should.equal('BigNumberGreaterThan');
-    }
-  });
-
-  it('should expose `message` on the violation if the input value is not a number', () => {
-    try {
-      new Assert().BigNumberGreaterThan(10).validate({});
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
-    }
-  });
-
-  it('should expose `threshold` on the violation', () => {
-    try {
-      new Assert().BigNumberGreaterThan(10).validate(0.1);
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.threshold.should.equal('10');
-    }
-  });
-
-  it('should accept a big number as a `threshold` value', () => {
-    new Assert().BigNumberGreaterThan(new BigNumber(10)).validate(10.00000001);
-  });
-
-  it('should accept a number that is greater than threshold', () => {
-    new Assert().BigNumberGreaterThan(10).validate(10.00000001);
   });
 });

--- a/test/asserts/big-number-greater-than-or-equal-to-assert_test.js
+++ b/test/asserts/big-number-greater-than-or-equal-to-assert_test.js
@@ -31,79 +31,84 @@ describe('BigNumberGreaterThanOrEqualToAssert', () => {
     }
   });
 
-  it('should throw an error if `threshold` is not a number', () => {
-    try {
-      new Assert().BigNumberGreaterThanOrEqualTo({});
+  [undefined, { validateSignificantDigits: true }, { validateSignificantDigits: false }].forEach(option => {
+    describe(`with option '${option ? `{ validateSignificantDigits: ${option.validateSignificantDigits} }` : undefined }'`, () => {
+      it('should throw an error if `threshold` is not a number', () => {
+        try {
+          new Assert().BigNumberGreaterThanOrEqualTo({}, option);
 
-      should.fail();
-    } catch (e) {
-      e.message.should.match(/not a number/);
-    }
-  });
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
 
-  it('should throw an error if the input value is not a number', () => {
-    const choices = [[], {}, ''];
+      it('should throw an error if the input value is not a number', () => {
+        const choices = [[], {}, ''];
 
-    choices.forEach(choice => {
-      try {
-        new Assert().BigNumberGreaterThanOrEqualTo(10).validate(choice);
+        choices.forEach(choice => {
+          try {
+            new Assert().BigNumberGreaterThanOrEqualTo(10, option).validate(choice);
 
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(Violation);
-      }
+            should.fail();
+          } catch (e) {
+            e.should.be.instanceOf(Violation);
+          }
+        });
+      });
+
+      it('should throw an error if the input number is less than the threshold', () => {
+        try {
+          new Assert().BigNumberGreaterThanOrEqualTo(10, option).validate(9.99999999);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should expose `assert` equal to `BigNumberGreaterThanOrEqualTo`', () => {
+        try {
+          new Assert().BigNumberGreaterThanOrEqualTo(1, option).validate(0.1);
+
+          should.fail();
+        } catch (e) {
+          e.show().assert.should.equal('BigNumberGreaterThanOrEqualTo');
+        }
+      });
+
+      it('should expose `message` on the violation if the input value is not a number', () => {
+        try {
+          new Assert().BigNumberGreaterThanOrEqualTo(10, option).validate({});
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
+
+      it('should expose `threshold` on the violation', () => {
+        try {
+          new Assert().BigNumberGreaterThanOrEqualTo(10, option).validate(0.1);
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.threshold.should.equal('10');
+        }
+      });
+
+      it('should accept a big number as a `threshold` value', () => {
+        new Assert().BigNumberGreaterThanOrEqualTo(new BigNumber(10), option).validate(10.00000001);
+      });
+
+      it('should accept a number that is greater than threshold', () => {
+        new Assert().BigNumberGreaterThanOrEqualTo(10, option).validate(10.00000001);
+      });
+
+      it('should accept a number that is equal to threshold', () => {
+        new Assert().BigNumberGreaterThanOrEqualTo(10, option).validate(10);
+      });
     });
-  });
-
-  it('should throw an error if the input number is less than the threshold', () => {
-    try {
-      new Assert().BigNumberGreaterThanOrEqualTo(10).validate(9.99999999);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should expose `assert` equal to `BigNumberGreaterThanOrEqualTo`', () => {
-    try {
-      new Assert().BigNumberGreaterThanOrEqualTo(1).validate(0.1);
-
-      should.fail();
-    } catch (e) {
-      e.show().assert.should.equal('BigNumberGreaterThanOrEqualTo');
-    }
-  });
-
-  it('should expose `message` on the violation if the input value is not a number', () => {
-    try {
-      new Assert().BigNumberGreaterThanOrEqualTo(10).validate({});
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
-    }
-  });
-
-  it('should expose `threshold` on the violation', () => {
-    try {
-      new Assert().BigNumberGreaterThanOrEqualTo(10).validate(0.1);
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.threshold.should.equal('10');
-    }
-  });
-
-  it('should accept a big number as a `threshold` value', () => {
-    new Assert().BigNumberGreaterThanOrEqualTo(new BigNumber(10)).validate(10.00000001);
-  });
-
-  it('should accept a number that is greater than threshold', () => {
-    new Assert().BigNumberGreaterThanOrEqualTo(10).validate(10.00000001);
-  });
-
-  it('should accept a number that is equal to threshold', () => {
-    new Assert().BigNumberGreaterThanOrEqualTo(10).validate(10);
   });
 });

--- a/test/asserts/big-number-less-than-assert_test.js
+++ b/test/asserts/big-number-less-than-assert_test.js
@@ -31,85 +31,90 @@ describe('BigNumberLessThanAssert', () => {
     }
   });
 
-  it('should throw an error if `threshold` is not a number', () => {
-    try {
-      new Assert().BigNumberLessThan({});
+  [undefined, { validateSignificantDigits: true }, { validateSignificantDigits: false }].forEach(option => {
+    describe(`with option '${option ? `{ validateSignificantDigits: ${option.validateSignificantDigits} }` : undefined }'`, () => {
+      it('should throw an error if `threshold` is not a number', () => {
+        try {
+          new Assert().BigNumberLessThan({}, option);
 
-      should.fail();
-    } catch (e) {
-      e.message.should.match(/not a number/);
-    }
-  });
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
 
-  it('should throw an error if the input value is not a number', () => {
-    const choices = [[], {}, ''];
+      it('should throw an error if the input value is not a number', () => {
+        const choices = [[], {}, ''];
 
-    choices.forEach(choice => {
-      try {
-        new Assert().BigNumberLessThan(10).validate(choice);
+        choices.forEach(choice => {
+          try {
+            new Assert().BigNumberLessThan(10, option).validate(choice);
 
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(Violation);
-      }
+            should.fail();
+          } catch (e) {
+            e.should.be.instanceOf(Violation);
+          }
+        });
+      });
+
+      it('should throw an error if the input number is equal to threshold', () => {
+        try {
+          new Assert().BigNumberLessThan(10, option).validate(10);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should throw an error if the input number is greater than the threshold', () => {
+        try {
+          new Assert().BigNumberLessThan(10, option).validate(10.01);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should expose `assert` equal to `BigNumberLessThan`', () => {
+        try {
+          new Assert().BigNumberLessThan(10, option).validate(10.01);
+
+          should.fail();
+        } catch (e) {
+          e.show().assert.should.equal('BigNumberLessThan');
+        }
+      });
+
+      it('should expose `message` on the violation if the input value is not a number', () => {
+        try {
+          new Assert().BigNumberLessThan(10, option).validate({});
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
+
+      it('should expose `threshold` on the violation', () => {
+        try {
+          new Assert().BigNumberLessThan(10, option).validate(10.01);
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.threshold.should.equal('10');
+        }
+      });
+
+      it('should accept a big number as a `threshold` value', () => {
+        new Assert().BigNumberLessThan(new BigNumber(10), option).validate(9.99999999);
+      });
+
+      it('should accept a number that is less than threshold', () => {
+        new Assert().BigNumberLessThan(10, option).validate(9.99999999);
+      });
     });
-  });
-
-  it('should throw an error if the input number is equal to threshold', () => {
-    try {
-      new Assert().BigNumberLessThan(10).validate(10);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should throw an error if the input number is greater than the threshold', () => {
-    try {
-      new Assert().BigNumberLessThan(10).validate(10.01);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should expose `assert` equal to `BigNumberLessThan`', () => {
-    try {
-      new Assert().BigNumberLessThan(10).validate(10.01);
-
-      should.fail();
-    } catch (e) {
-      e.show().assert.should.equal('BigNumberLessThan');
-    }
-  });
-
-  it('should expose `message` on the violation if the input value is not a number', () => {
-    try {
-      new Assert().BigNumberLessThan(10).validate({});
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
-    }
-  });
-
-  it('should expose `threshold` on the violation', () => {
-    try {
-      new Assert().BigNumberLessThan(10).validate(10.01);
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.threshold.should.equal('10');
-    }
-  });
-
-  it('should accept a big number as a `threshold` value', () => {
-    new Assert().BigNumberLessThan(new BigNumber(10)).validate(9.99999999);
-  });
-
-  it('should accept a number that is less than threshold', () => {
-    new Assert().BigNumberLessThan(10).validate(9.99999999);
   });
 });

--- a/test/asserts/big-number-less-than-or-equal-to-assert_test.js
+++ b/test/asserts/big-number-less-than-or-equal-to-assert_test.js
@@ -31,79 +31,84 @@ describe('BigNumberLessThanOrEqualToAssert', () => {
     }
   });
 
-  it('should throw an error if `threshold` is not a number', () => {
-    try {
-      new Assert().BigNumberLessThanOrEqualTo({});
+  [undefined, { validateSignificantDigits: true }, { validateSignificantDigits: false }].forEach(option => {
+    describe(`with option '${option ? `{ validateSignificantDigits: ${option.validateSignificantDigits} }` : undefined }'`, () => {
+      it('should throw an error if `threshold` is not a number', () => {
+        try {
+          new Assert().BigNumberLessThanOrEqualTo({}, option);
 
-      should.fail();
-    } catch (e) {
-      e.message.should.match(/not a number/);
-    }
-  });
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
 
-  it('should throw an error if the input value is not a number', () => {
-    const choices = [[], {}, ''];
+      it('should throw an error if the input value is not a number', () => {
+        const choices = [[], {}, ''];
 
-    choices.forEach(choice => {
-      try {
-        new Assert().BigNumberLessThanOrEqualTo(10).validate(choice);
+        choices.forEach(choice => {
+          try {
+            new Assert().BigNumberLessThanOrEqualTo(10, option).validate(choice);
 
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(Violation);
-      }
+            should.fail();
+          } catch (e) {
+            e.should.be.instanceOf(Violation);
+          }
+        });
+      });
+
+      it('should throw an error if the input number is greater than the threshold', () => {
+        try {
+          new Assert().BigNumberLessThanOrEqualTo(10, option).validate(10.0000000001);
+
+          should.fail();
+        } catch (e) {
+          e.should.be.instanceOf(Violation);
+        }
+      });
+
+      it('should expose `assert` equal to `BigNumberLessThanOrEqualTo`', () => {
+        try {
+          new Assert().BigNumberLessThanOrEqualTo(10, option).validate(10.01);
+
+          should.fail();
+        } catch (e) {
+          e.show().assert.should.equal('BigNumberLessThanOrEqualTo');
+        }
+      });
+
+      it('should expose `message` on the violation if the input value is not a number', () => {
+        try {
+          new Assert().BigNumberLessThanOrEqualTo(10, option).validate({});
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.message.should.match(/Not a number/);
+        }
+      });
+
+      it('should expose `threshold` on the violation', () => {
+        try {
+          new Assert().BigNumberLessThanOrEqualTo(10, option).validate(10.01);
+
+          should.fail();
+        } catch (e) {
+          e.show().violation.threshold.should.equal('10');
+        }
+      });
+
+      it('should accept a big number as a `threshold` value', () => {
+        new Assert().BigNumberLessThanOrEqualTo(new BigNumber(10), option).validate(9.99999999);
+      });
+
+      it('should accept a number that is less than threshold', () => {
+        new Assert().BigNumberLessThanOrEqualTo(10, option).validate(9.99999999);
+      });
+
+      it('should accept a number that is equal to threshold', () => {
+        new Assert().BigNumberLessThanOrEqualTo(10, option).validate(10);
+      });
     });
-  });
-
-  it('should throw an error if the input number is greater than the threshold', () => {
-    try {
-      new Assert().BigNumberLessThanOrEqualTo(10).validate(10.0000000001);
-
-      should.fail();
-    } catch (e) {
-      e.should.be.instanceOf(Violation);
-    }
-  });
-
-  it('should expose `assert` equal to `BigNumberLessThanOrEqualTo`', () => {
-    try {
-      new Assert().BigNumberLessThanOrEqualTo(10).validate(10.01);
-
-      should.fail();
-    } catch (e) {
-      e.show().assert.should.equal('BigNumberLessThanOrEqualTo');
-    }
-  });
-
-  it('should expose `message` on the violation if the input value is not a number', () => {
-    try {
-      new Assert().BigNumberLessThanOrEqualTo(10).validate({});
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
-    }
-  });
-
-  it('should expose `threshold` on the violation', () => {
-    try {
-      new Assert().BigNumberLessThanOrEqualTo(10).validate(10.01);
-
-      should.fail();
-    } catch (e) {
-      e.show().violation.threshold.should.equal('10');
-    }
-  });
-
-  it('should accept a big number as a `threshold` value', () => {
-    new Assert().BigNumberLessThanOrEqualTo(new BigNumber(10)).validate(9.99999999);
-  });
-
-  it('should accept a number that is less than threshold', () => {
-    new Assert().BigNumberLessThanOrEqualTo(10).validate(9.99999999);
-  });
-
-  it('should accept a number that is equal to threshold', () => {
-    new Assert().BigNumberLessThanOrEqualTo(10).validate(10);
   });
 });


### PR DESCRIPTION
`bignumber.js` version 7 introduced a breaking change:
> Only throw on an invalid BigNumber value if BigNumber.DEBUG is true. Return BigNumber NaN instead.

For projects that used the newer versions of `bignumber.js`, the assert `is.bigNumber()` and similar were not working when the input was invalid (internally the `new BigNumber()` was not throwing like before).

Version 6 also added the following breaking change:
> Rename methods: add is prefix to greaterThan, greaterThanOrEqualTo, lessThan and lessThanOrEqualTo.

This PR adds support for versions 7 and above.

It also adds support for an option `validateSignificantDigits ` flag, wich controls the behaviour of the validator when the input is a number with more than 15 significant digits.

- Before bignumber.js@7 and this PR:
```js
> new BigNumber(1.011111111111111111111111111111111111111111)
{ BigNumber Error: new BigNumber() number type has more than 15 significant digits: 1.011111111111111
    at raise [...]
```
- After bignumber.js@7  and after this PR with `validateSignificantDigits = true` (default):
```js
> BigNumber.DEBUG = false
> new BigNumber(1.011111111111111111111111111111111111111111)
Error: [BigNumber Error] Number primitive has more than 15 significant digits: 1.011111111111111  
    at new BigNumber [...]
```
- After bignumber.js@7 and after this PR with `validateSignificantDigits = false`:
```js
> BigNumber.DEBUG = true
> new BigNumber(1.011111111111111111111111111111111111111111)
1.011111111111111
```
With `validateSignificantDigits = false` we don't throw an error if the input value is a number with more than 15 digits of precision, but to avoid losing precision the value should be converted to a string first:
```js
> BigNumber.DEBUG = true
> new BigNumber('1.011111111111111111111111111111111111111111')
1.011111111111111111111111111111111111111111
```

