### PR TITLE
Update bignumber.js@8.0.2

### DIFF
--- a/dist/asserts/big-number-assert.js
+++ b/dist/asserts/big-number-assert.js
@@ -29,6 +29,8 @@ function bigNumberAssert() {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       new BigNumber(value); // eslint-disable-line no-new
     } catch (e) {

--- a/dist/asserts/big-number-equal-to-assert.js
+++ b/dist/asserts/big-number-equal-to-assert.js
@@ -35,16 +35,18 @@ function bigNumberEqualToAssert(value) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.equals(this.value)) {
+      if (!number.isEqualTo(this.value)) {
         throw new Error();
       }
     } catch (e) {
       const context = { value: this.value.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/dist/asserts/big-number-greater-than-assert.js
+++ b/dist/asserts/big-number-greater-than-assert.js
@@ -35,16 +35,18 @@ function bigNumberGreaterThanAssert(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.greaterThan(this.threshold)) {
+      if (!number.isGreaterThan(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/dist/asserts/big-number-greater-than-or-equal-to-assert.js
+++ b/dist/asserts/big-number-greater-than-or-equal-to-assert.js
@@ -35,16 +35,18 @@ function bigNumberGreaterThanOrEqualToAssert(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.greaterThanOrEqualTo(this.threshold)) {
+      if (!number.isGreaterThanOrEqualTo(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/dist/asserts/big-number-less-than-assert.js
+++ b/dist/asserts/big-number-less-than-assert.js
@@ -35,16 +35,18 @@ function bigNumberLessThan(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.lessThan(this.threshold)) {
+      if (!number.isLessThan(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/dist/asserts/big-number-less-than-or-equal-to-assert.js
+++ b/dist/asserts/big-number-less-than-or-equal-to-assert.js
@@ -35,16 +35,18 @@ function bigNumberLessThanOrEqualToAssert(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.lessThanOrEqualTo(this.threshold)) {
+      if (!number.isLessThanOrEqualTo(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/dist/asserts/phone-assert.js
+++ b/dist/asserts/phone-assert.js
@@ -62,7 +62,7 @@ function phoneAssert() {
       }
 
       if (this.countryCode && !phoneUtil.isValidNumberForRegion(phone, this.countryCode)) {
-        throw new Error(`Phone does not belong to country "${ this.countryCode }"`);
+        throw new Error(`Phone does not belong to country "${this.countryCode}"`);
       }
     } catch (e) {
       throw new _validator.Violation(this, value);

--- a/dist/asserts/uk-modulus-checking-assert.js
+++ b/dist/asserts/uk-modulus-checking-assert.js
@@ -33,8 +33,8 @@ function ukModulusCheckingAssert() {
   this.validate = function () {
     var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
-    let accountNumber = _ref.accountNumber;
-    let sortCode = _ref.sortCode;
+    let accountNumber = _ref.accountNumber,
+        sortCode = _ref.sortCode;
 
     if (typeof accountNumber !== 'string') {
       throw new _validator.Violation(_this, accountNumber, { accountNumber: _validator.Validator.errorCode.must_be_a_string });

--- a/dist/asserts/uri-assert.js
+++ b/dist/asserts/uri-assert.js
@@ -42,7 +42,7 @@ function uriAssert(constraints) {
 
   (0, _lodash.forEach)(this.constraints, (constraint, key) => {
     if (!(0, _lodash.has)(URI.prototype, key)) {
-      throw new Error(`Invalid constraint "${ key }=${ constraint }"`);
+      throw new Error(`Invalid constraint "${key}=${constraint}"`);
     }
   });
 

--- a/dist/asserts/us-subdivision-assert.js
+++ b/dist/asserts/us-subdivision-assert.js
@@ -30,9 +30,9 @@ const keys = Object.keys(subdivisions);
  */
 
 function usSubdivisionAssert() {
-  var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var _ref = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
+      _ref$categories = _ref.categories;
 
-  var _ref$categories = _ref.categories;
   let categories = _ref$categories === undefined ? keys : _ref$categories;
   var _ref$alpha2Only = _ref.alpha2Only;
   let alpha2Only = _ref$alpha2Only === undefined ? false : _ref$alpha2Only;
@@ -48,7 +48,7 @@ function usSubdivisionAssert() {
    */
 
   if (categories && (0, _lodash.intersection)(keys, categories).length !== categories.length) {
-    throw new Error(`Unsupported categories "${ (0, _lodash.difference)(categories, keys) }" given`);
+    throw new Error(`Unsupported categories "${(0, _lodash.difference)(categories, keys)}" given`);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.7.2",
-    "bignumber.js": "^2.3.0",
+    "bignumber.js": "^8.0.2",
     "creditcard": "^0.1.2",
     "eslint": "^2.8.0",
     "eslint-config-seegno": "^4.0.0",
@@ -77,7 +77,7 @@
   },
   "optionalPeerDependencies": {
     "abavalidator": ">=2 <3",
-    "bignumber.js": ">=2 <3",
+    "bignumber.js": ">=6 <9",
     "creditcard": ">=0.0.1 <1.0.0",
     "google-libphonenumber": ">=1 <4",
     "iban": ">=0.0.6 <1.0.0",

--- a/src/asserts/big-number-assert.js
+++ b/src/asserts/big-number-assert.js
@@ -27,6 +27,8 @@ export default function bigNumberAssert() {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       new BigNumber(value); // eslint-disable-line no-new
     } catch (e) {

--- a/src/asserts/big-number-equal-to-assert.js
+++ b/src/asserts/big-number-equal-to-assert.js
@@ -33,16 +33,18 @@ export default function bigNumberEqualToAssert(value) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.equals(this.value)) {
+      if (!number.isEqualTo(this.value)) {
         throw new Error();
       }
     } catch (e) {
       const context = { value: this.value.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/src/asserts/big-number-greater-than-assert.js
+++ b/src/asserts/big-number-greater-than-assert.js
@@ -33,16 +33,18 @@ export default function bigNumberGreaterThanAssert(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.greaterThan(this.threshold)) {
+      if (!number.isGreaterThan(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/src/asserts/big-number-greater-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-greater-than-or-equal-to-assert.js
@@ -33,16 +33,18 @@ export default function bigNumberGreaterThanOrEqualToAssert(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.greaterThanOrEqualTo(this.threshold)) {
+      if (!number.isGreaterThanOrEqualTo(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/src/asserts/big-number-less-than-assert.js
+++ b/src/asserts/big-number-less-than-assert.js
@@ -33,16 +33,18 @@ export default function bigNumberLessThan(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.lessThan(this.threshold)) {
+      if (!number.isLessThan(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/src/asserts/big-number-less-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-less-than-or-equal-to-assert.js
@@ -33,16 +33,18 @@ export default function bigNumberLessThanOrEqualToAssert(threshold) {
    */
 
   this.validate = value => {
+    BigNumber.DEBUG = true;
+
     try {
       const number = new BigNumber(value);
 
-      if (!number.lessThanOrEqualTo(this.threshold)) {
+      if (!number.isLessThanOrEqualTo(this.threshold)) {
         throw new Error();
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
 
-      if (e.name === 'BigNumber Error') {
+      if (e.message.startsWith('[BigNumber Error]')) {
         context.message = e.message;
       }
 

--- a/test/asserts/big-number-equal-to-assert_test.js
+++ b/test/asserts/big-number-equal-to-assert_test.js
@@ -37,7 +37,7 @@ describe('BigNumberEqualToAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.message.should.match(/not a number/);
+      e.message.should.match(/Not a number/);
     }
   });
 
@@ -91,7 +91,7 @@ describe('BigNumberEqualToAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
+      e.show().violation.message.should.match(/Not a number/);
     }
   });
 

--- a/test/asserts/big-number-greater-than-assert_test.js
+++ b/test/asserts/big-number-greater-than-assert_test.js
@@ -37,7 +37,7 @@ describe('BigNumberGreaterThanAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.message.should.match(/not a number/);
+      e.message.should.match(/Not a number/);
     }
   });
 
@@ -91,7 +91,7 @@ describe('BigNumberGreaterThanAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
+      e.show().violation.message.should.match(/Not a number/);
     }
   });
 

--- a/test/asserts/big-number-greater-than-or-equal-to-assert_test.js
+++ b/test/asserts/big-number-greater-than-or-equal-to-assert_test.js
@@ -37,7 +37,7 @@ describe('BigNumberGreaterThanOrEqualToAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.message.should.match(/not a number/);
+      e.message.should.match(/Not a number/);
     }
   });
 
@@ -81,7 +81,7 @@ describe('BigNumberGreaterThanOrEqualToAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
+      e.show().violation.message.should.match(/Not a number/);
     }
   });
 

--- a/test/asserts/big-number-less-than-assert_test.js
+++ b/test/asserts/big-number-less-than-assert_test.js
@@ -37,7 +37,7 @@ describe('BigNumberLessThanAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.message.should.match(/not a number/);
+      e.message.should.match(/Not a number/);
     }
   });
 
@@ -91,7 +91,7 @@ describe('BigNumberLessThanAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
+      e.show().violation.message.should.match(/Not a number/);
     }
   });
 

--- a/test/asserts/big-number-less-than-or-equal-to-assert_test.js
+++ b/test/asserts/big-number-less-than-or-equal-to-assert_test.js
@@ -37,7 +37,7 @@ describe('BigNumberLessThanOrEqualToAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.message.should.match(/not a number/);
+      e.message.should.match(/Not a number/);
     }
   });
 
@@ -81,7 +81,7 @@ describe('BigNumberLessThanOrEqualToAssert', () => {
 
       should.fail();
     } catch (e) {
-      e.show().violation.message.should.match(/not a number/);
+      e.show().violation.message.should.match(/Not a number/);
     }
   });
 


### PR DESCRIPTION
This will enable projects that depend on validator.js-asserts to update their versions of bignumber.js.

Note: this PR introduces a breaking change because of how the bignumber.js interface changed between versions. Releasing it should require a major version bump.