### PR TITLE
Update `changelog` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,190 +1,86 @@
 # Changelog
 
-## [v3.1.0](https://github.com/uphold/validator.js-asserts/tree/v3.1.0) (2016-10-20)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v3.0.2...v3.1.0)
-
-**Implemented enhancements:**
-
+## [3.1.0](https://github.com/uphold/validator.js-asserts/releases/tag/3.1.0) (2019-02-18)
+- Support bignumber.js@7+ and add optional `validateSignificantDigits` flag [\#174](https://github.com/uphold/validator.js-asserts/pull/174) ([ricardobcl](https://github.com/ricardobcl))
+- Update google-libphonenumber [\#173](https://github.com/uphold/validator.js-asserts/pull/173) ([rplopes](https://github.com/rplopes))
+- Update ownership [\#169](https://github.com/uphold/validator.js-asserts/pull/169) ([ruimarinho](https://github.com/ruimarinho))
+- Update README to include new asserts [\#165](https://github.com/uphold/validator.js-asserts/pull/165) ([kurayama](https://github.com/kurayama))
 - New date asserts [\#164](https://github.com/uphold/validator.js-asserts/pull/164) ([kurayama](https://github.com/kurayama))
-
-## [v3.0.2](https://github.com/uphold/validator.js-asserts/tree/v3.0.2) (2016-10-10)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v3.0.1...v3.0.2)
-
-**Closed issues:**
-
-- Incorrect documentation for `Uuid` assert [\#148](https://github.com/uphold/validator.js-asserts/issues/148)
-
-**Merged pull requests:**
-
 - Allow custom date formats [\#150](https://github.com/uphold/validator.js-asserts/pull/150) ([kurayama](https://github.com/kurayama))
-
-## [v3.0.1](https://github.com/uphold/validator.js-asserts/tree/v3.0.1) (2016-08-04)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v3.0.0...v3.0.1)
-
-**Implemented enhancements:**
-
 - Add `BigNumberEqualTo` assert [\#117](https://github.com/uphold/validator.js-asserts/pull/117) ([nunofgs](https://github.com/nunofgs))
-
-## [v3.0.0](https://github.com/uphold/validator.js-asserts/tree/v3.0.0) (2016-05-13)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v2.3.1...v3.0.0)
-
-**Implemented enhancements:**
-
 - Update validator.js@2.0.0 [\#110](https://github.com/uphold/validator.js-asserts/pull/110) ([ruimarinho](https://github.com/ruimarinho))
-
-## [v2.3.1](https://github.com/uphold/validator.js-asserts/tree/v2.3.1) (2016-04-29)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v2.3.0...v2.3.1)
-
-**Merged pull requests:**
-
 - Update uk-modulus-checking@0.0.3 [\#105](https://github.com/uphold/validator.js-asserts/pull/105) ([promag](https://github.com/promag))
 - Update dependencies [\#103](https://github.com/uphold/validator.js-asserts/pull/103) ([ruimarinho](https://github.com/ruimarinho))
 
-## [v2.3.0](https://github.com/uphold/validator.js-asserts/tree/v2.3.0) (2016-04-14)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v2.2.0...v2.3.0)
-
-**Implemented enhancements:**
-
+## [v2.3.0](https://github.com/uphold/validator.js-asserts/releases/tag/v2.3.0) (2016-04-14)
 - Add Taxpayer Identification Number assert [\#66](https://github.com/uphold/validator.js-asserts/pull/66) ([nunofgs](https://github.com/nunofgs))
 
-## [v2.2.0](https://github.com/uphold/validator.js-asserts/tree/v2.2.0) (2016-04-10)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v2.1.0...v2.2.0)
-
-**Implemented enhancements:**
-
+## [v2.2.0](https://github.com/uphold/validator.js-asserts/releases/tag/v2.2.0) (2016-04-10)
+- Add UkModulusChecking assert [\#79](https://github.com/uphold/validator.js-asserts/pull/79) ([franciscocardoso](https://github.com/franciscocardoso))
 - Add note about `Date` assert requiring `moment` for format validation [\#97](https://github.com/uphold/validator.js-asserts/pull/97) ([ruimarinho](https://github.com/ruimarinho))
 
-**Merged pull requests:**
-
-- Add UkModulusChecking assert [\#79](https://github.com/uphold/validator.js-asserts/pull/79) ([franciscocardoso](https://github.com/franciscocardoso))
-
-## [v2.1.0](https://github.com/uphold/validator.js-asserts/tree/v2.1.0) (2016-04-10)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v2.0.2...v2.1.0)
-
-**Merged pull requests:**
-
+## [v2.1.0](https://github.com/uphold/validator.js-asserts/releases/tag/v2.1.0) (2016-04-10)
 - Add release instructions [\#96](https://github.com/uphold/validator.js-asserts/pull/96) ([ruimarinho](https://github.com/ruimarinho))
+
+## [v2.0.2](https://github.com/uphold/validator.js-asserts/releases/tag/v2.0.2) (2016-04-10)
+
+## [v2.0.1](https://github.com/uphold/validator.js-asserts/releases/tag/v2.0.1) (2016-04-10)
+
+## [v2.0.0](https://github.com/uphold/validator.js-asserts/releases/tag/v2.0.0) (2016-04-10)
+
+## [v1.1.0](https://github.com/uphold/validator.js-asserts/releases/tag/v1.1.0) (2016-04-10)
+
+## [v1.0.0](https://github.com/uphold/validator.js-asserts/releases/tag/v1.0.0) (2016-04-10)
+
+## [v0.0.7](https://github.com/uphold/validator.js-asserts/releases/tag/v0.0.7) (2016-04-10)
+
+## [v0.0.6](https://github.com/uphold/validator.js-asserts/releases/tag/v0.0.6) (2016-04-10)
+
+## [v0.0.5](https://github.com/uphold/validator.js-asserts/releases/tag/v0.0.5) (2016-04-10)
+
+## [v0.0.4](https://github.com/uphold/validator.js-asserts/releases/tag/v0.0.4) (2016-04-10)
+
+## [v0.0.3](https://github.com/uphold/validator.js-asserts/releases/tag/v0.0.3) (2016-04-10)
+
+## [v0.0.2](https://github.com/uphold/validator.js-asserts/releases/tag/v0.0.2) (2016-04-10)
 - Add format option to date assert [\#95](https://github.com/uphold/validator.js-asserts/pull/95) ([franciscocardoso](https://github.com/franciscocardoso))
-
-## [v2.0.2](https://github.com/uphold/validator.js-asserts/tree/v2.0.2) (2016-04-06)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v2.0.1...v2.0.2)
-
-**Implemented enhancements:**
-
-- Add automated releases [\#74](https://github.com/uphold/validator.js-asserts/pull/74) ([ruimarinho](https://github.com/ruimarinho))
-
-**Merged pull requests:**
-
 - Update dependencies [\#94](https://github.com/uphold/validator.js-asserts/pull/94) ([ruimarinho](https://github.com/ruimarinho))
+- Add automated releases [\#74](https://github.com/uphold/validator.js-asserts/pull/74) ([ruimarinho](https://github.com/ruimarinho))
 - Update dependencies [\#73](https://github.com/uphold/validator.js-asserts/pull/73) ([ruimarinho](https://github.com/ruimarinho))
 - Remove jscs inline camel case rules [\#65](https://github.com/uphold/validator.js-asserts/pull/65) ([nunofgs](https://github.com/nunofgs))
-
-## [v2.0.1](https://github.com/uphold/validator.js-asserts/tree/v2.0.1) (2016-01-26)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v2.0.0...v2.0.1)
-
-**Fixed bugs:**
-
-- Fix abavalidator not being considered optional [\#63](https://github.com/uphold/validator.js-asserts/pull/63) ([ruimarinho](https://github.com/ruimarinho))
-
-**Merged pull requests:**
-
 - Add module exports [\#64](https://github.com/uphold/validator.js-asserts/pull/64) ([ruimarinho](https://github.com/ruimarinho))
-
-## [v2.0.0](https://github.com/uphold/validator.js-asserts/tree/v2.0.0) (2016-01-21)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v1.1.0...v2.0.0)
-
-**Implemented enhancements:**
-
+- Fix abavalidator not being considered optional [\#63](https://github.com/uphold/validator.js-asserts/pull/63) ([ruimarinho](https://github.com/ruimarinho))
 - Code style improvements [\#62](https://github.com/uphold/validator.js-asserts/pull/62) ([ruimarinho](https://github.com/ruimarinho))
 - Add missing Phone assert test for valid phone [\#61](https://github.com/uphold/validator.js-asserts/pull/61) ([ruimarinho](https://github.com/ruimarinho))
+- Deprecate Country assert [\#60](https://github.com/uphold/validator.js-asserts/pull/60) ([ruimarinho](https://github.com/ruimarinho))
 - Beautify README [\#59](https://github.com/uphold/validator.js-asserts/pull/59) ([ruimarinho](https://github.com/ruimarinho))
-- Add support for the special `is` urijs constraint [\#58](https://github.com/uphold/validator.js-asserts/pull/58) ([ruimarinho](https://github.com/ruimarinho))
-- Add US Zip Code assert [\#54](https://github.com/uphold/validator.js-asserts/pull/54) ([promag](https://github.com/promag))
 - Add Phone assert [\#53](https://github.com/uphold/validator.js-asserts/pull/53) ([promag](https://github.com/promag))
+- Add US Zip Code assert [\#54](https://github.com/uphold/validator.js-asserts/pull/54) ([promag](https://github.com/promag))
+- Add support for the special `is` urijs constraint [\#58](https://github.com/uphold/validator.js-asserts/pull/58) ([ruimarinho](https://github.com/ruimarinho))
+- Update should to version 8.1.1 🚀 [\#56](https://github.com/uphold/validator.js-asserts/pull/56) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Update lodash to version 4.0.0 🚀 [\#57](https://github.com/uphold/validator.js-asserts/pull/57) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
 - Add ABA Routing Number assert [\#52](https://github.com/uphold/validator.js-asserts/pull/52) ([promag](https://github.com/promag))
 - Handle empty objects in `EqualKeys` [\#50](https://github.com/uphold/validator.js-asserts/pull/50) ([ruimarinho](https://github.com/ruimarinho))
-- Drop support for node \< 4 [\#49](https://github.com/uphold/validator.js-asserts/pull/49) ([ruimarinho](https://github.com/ruimarinho))
+- Drop support for node < 4 [\#49](https://github.com/uphold/validator.js-asserts/pull/49) ([ruimarinho](https://github.com/ruimarinho))
 - Reimplement `UsState` as `UsSubdivision` [\#22](https://github.com/uphold/validator.js-asserts/pull/22) ([promag](https://github.com/promag))
-
-**Fixed bugs:**
-
-- Fix asserts always requiring peer dependencies [\#31](https://github.com/uphold/validator.js-asserts/issues/31)
-- Fix peer dependencies being required directly [\#35](https://github.com/uphold/validator.js-asserts/pull/35) ([nunofgs](https://github.com/nunofgs))
-
-**Closed issues:**
-
-- Add AcceptKeys assert [\#43](https://github.com/uphold/validator.js-asserts/issues/43)
-
-**Merged pull requests:**
-
-- Deprecate Country assert [\#60](https://github.com/uphold/validator.js-asserts/pull/60) ([ruimarinho](https://github.com/ruimarinho))
-- Update lodash to version 4.0.0 🚀 [\#57](https://github.com/uphold/validator.js-asserts/pull/57) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-- Update should to version 8.1.1 🚀 [\#56](https://github.com/uphold/validator.js-asserts/pull/56) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
 - iban@0.0.6 breaks build 🚨 [\#39](https://github.com/uphold/validator.js-asserts/pull/39) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-
-## [v1.1.0](https://github.com/uphold/validator.js-asserts/tree/v1.1.0) (2015-10-16)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v1.0.0...v1.1.0)
-
-**Merged pull requests:**
-
+- Fix peer dependencies being required directly [\#35](https://github.com/uphold/validator.js-asserts/pull/35) ([nunofgs](https://github.com/nunofgs))
 - Update all dependencies 🌴 [\#27](https://github.com/uphold/validator.js-asserts/pull/27) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- Add International Bank Account Number assert [\#23](https://github.com/uphold/validator.js-asserts/pull/23) ([nunofgs](https://github.com/nunofgs))
 - Add missing comment to credit card test [\#26](https://github.com/uphold/validator.js-asserts/pull/26) ([nunofgs](https://github.com/nunofgs))
 - Add Bank Identifier Code assert [\#24](https://github.com/uphold/validator.js-asserts/pull/24) ([nunofgs](https://github.com/nunofgs))
-- Add International Bank Account Number assert [\#23](https://github.com/uphold/validator.js-asserts/pull/23) ([nunofgs](https://github.com/nunofgs))
-
-## [v1.0.0](https://github.com/uphold/validator.js-asserts/tree/v1.0.0) (2015-08-11)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v0.0.7...v1.0.0)
-
-**Merged pull requests:**
-
 - Refactor using ES6 [\#20](https://github.com/uphold/validator.js-asserts/pull/20) ([ruimarinho](https://github.com/ruimarinho))
 - Move dependencies to peer dependencies [\#19](https://github.com/uphold/validator.js-asserts/pull/19) ([ruimarinho](https://github.com/ruimarinho))
-
-## [v0.0.7](https://github.com/uphold/validator.js-asserts/tree/v0.0.7) (2015-05-25)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v0.0.6...v0.0.7)
-
-**Merged pull requests:**
-
 - Add null or date assert [\#17](https://github.com/uphold/validator.js-asserts/pull/17) ([nunofgs](https://github.com/nunofgs))
-
-## [v0.0.6](https://github.com/uphold/validator.js-asserts/tree/v0.0.6) (2015-05-25)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v0.0.5...v0.0.6)
-
-**Merged pull requests:**
-
 - Export object for validator.js extend method usage [\#16](https://github.com/uphold/validator.js-asserts/pull/16) ([ruimarinho](https://github.com/ruimarinho))
 - Add documentation for uri assert [\#15](https://github.com/uphold/validator.js-asserts/pull/15) ([ruimarinho](https://github.com/ruimarinho))
-
-## [v0.0.5](https://github.com/uphold/validator.js-asserts/tree/v0.0.5) (2015-05-24)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v0.0.4...v0.0.5)
-
-**Merged pull requests:**
-
 - Use travis container infrastructure [\#14](https://github.com/uphold/validator.js-asserts/pull/14) ([ruimarinho](https://github.com/ruimarinho))
-- Replace ISO 3166-1 country assert source [\#13](https://github.com/uphold/validator.js-asserts/pull/13) ([ruimarinho](https://github.com/ruimarinho))
 - Add URI assert [\#12](https://github.com/uphold/validator.js-asserts/pull/12) ([nunofgs](https://github.com/nunofgs))
-
-## [v0.0.4](https://github.com/uphold/validator.js-asserts/tree/v0.0.4) (2015-01-16)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v0.0.3...v0.0.4)
-
-**Merged pull requests:**
-
+- Replace ISO 3166-1 country assert source [\#13](https://github.com/uphold/validator.js-asserts/pull/13) ([ruimarinho](https://github.com/ruimarinho))
 - Update bignumber.js version [\#7](https://github.com/uphold/validator.js-asserts/pull/7) ([fixe](https://github.com/fixe))
-
-## [v0.0.3](https://github.com/uphold/validator.js-asserts/tree/v0.0.3) (2014-12-01)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v0.0.2...v0.0.3)
-
-**Merged pull requests:**
-
 - Update asserts documentation [\#6](https://github.com/uphold/validator.js-asserts/pull/6) ([ruimarinho](https://github.com/ruimarinho))
 - Update github-changes@0.0.16 [\#5](https://github.com/uphold/validator.js-asserts/pull/5) ([ruimarinho](https://github.com/ruimarinho))
-- Remove extra console message from email test [\#4](https://github.com/uphold/validator.js-asserts/pull/4) ([ruimarinho](https://github.com/ruimarinho))
 - Add date diff less and greater than asserts [\#3](https://github.com/uphold/validator.js-asserts/pull/3) ([ruimarinho](https://github.com/ruimarinho))
-
-## [v0.0.2](https://github.com/uphold/validator.js-asserts/tree/v0.0.2) (2014-11-26)
-[Full Changelog](https://github.com/uphold/validator.js-asserts/compare/v0.0.1...v0.0.2)
-
-**Merged pull requests:**
-
-- Expose min and max in `NullOrString` [\#2](https://github.com/uphold/validator.js-asserts/pull/2) ([fixe](https://github.com/fixe))
+- Remove extra console message from email test [\#4](https://github.com/uphold/validator.js-asserts/pull/4) ([ruimarinho](https://github.com/ruimarinho))
 - Add `Email` assert [\#1](https://github.com/uphold/validator.js-asserts/pull/1) ([fixe](https://github.com/fixe))
+- Expose min and max in `NullOrString` [\#2](https://github.com/uphold/validator.js-asserts/pull/2) ([fixe](https://github.com/fixe))

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "--compilers js:babel-register --recursive test"
   },
   "scripts": {
-    "changelog": "github_changelog_generator --header-label='# Changelog' --future-release=v$npm_config_future_release && sed -i '' -e :a -e '$d;N;2,4ba' -e 'P;D' CHANGELOG.md",
+    "changelog": "github-changelog-generator --future-release=$npm_package_version > CHANGELOG.md",
     "cover": "babel-node node_modules/.bin/isparta cover --report html _mocha -- $npm_package_options_mocha",
     "lint": "eslint src test && jscs src test",
     "prepublish": "npm run transpile",
@@ -48,6 +48,7 @@
     "validator.js": "^2.0.0"
   },
   "devDependencies": {
+    "@uphold/github-changelog-generator": "^0.8.0",
     "abavalidator": "^2.0.1",
     "babel-cli": "^6.7.7",
     "babel-eslint": "^6.0.3",


### PR DESCRIPTION
This PR updates the `changelog` script to the newer and simpler format.

It also explicitly adds a dev dependency to `@uphold/github-changelog-generator`.