### PR TITLE
Fix date tests on node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 4
   - 5
+  - 10
 
 after_success:
   - npm run cover

--- a/test/asserts/date-diff-greater-than-assert_test.js
+++ b/test/asserts/date-diff-greater-than-assert_test.js
@@ -150,7 +150,7 @@ describe('DateDiffGreaterThanAssert', () => {
 
   it('should throw an error if the diff between `fromDate` and input date is less than the `threshold`', () => {
     try {
-      new Assert().DateDiffGreaterThan(24 * 60 * 60 * 1000, { fromDate: new Date('1970-01-01 00:00:00') }).validate(new Date('1970-01-01 10:00:00'));
+      new Assert().DateDiffGreaterThan(24 * 60 * 60 * 1000, { fromDate: new Date('1970-01-01') }).validate(new Date('1970-01-01 10:00:00Z'));
 
       should.fail();
     } catch (e) {
@@ -208,7 +208,7 @@ describe('DateDiffGreaterThanAssert', () => {
 
   it('should use the `asFloat` option supplied', () => {
     try {
-      new Assert().DateDiffGreaterThan(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00'), unit: 'minutes' }).validate(new Date('1970-01-01 10:04:51'));
+      new Assert().DateDiffGreaterThan(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'minutes' }).validate(new Date('1970-01-01 10:04:51Z'));
 
       should.fail();
     } catch (e) {
@@ -219,7 +219,7 @@ describe('DateDiffGreaterThanAssert', () => {
 
   it('should use the `unit` option supplied', () => {
     try {
-      new Assert().DateDiffGreaterThan(2000, { fromDate: new Date('1970-01-01 10:00:00'), unit: 'seconds' }).validate(new Date('1970-01-01 10:00:05'));
+      new Assert().DateDiffGreaterThan(2000, { fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'seconds' }).validate(new Date('1970-01-01 10:00:05Z'));
 
       should.fail();
     } catch (e) {
@@ -230,7 +230,7 @@ describe('DateDiffGreaterThanAssert', () => {
   it('should accept a date whose diff from `now` is greater than the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffGreaterThan(24 * 60 * 60 * 1000).validate(new Date('1969-12-30 00:00:00'));
+    new Assert().DateDiffGreaterThan(24 * 60 * 60 * 1000).validate(new Date('1969-12-30'));
 
     clock.restore();
   });
@@ -238,16 +238,16 @@ describe('DateDiffGreaterThanAssert', () => {
   it('should accept a date whose `absolute` diff from `now` is greater than the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffGreaterThan(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-03 00:00:00'));
+    new Assert().DateDiffGreaterThan(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-03'));
 
     clock.restore();
   });
 
   it('should accept a date whose diff from `fromDate` is greater than the threshold', () => {
-    new Assert().DateDiffGreaterThan(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-30 00:00:00'));
+    new Assert().DateDiffGreaterThan(24, { asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1969-12-30'));
   });
 
   it('should accept a date whose `absolute` diff from `fromDate` is greater than the threshold', () => {
-    new Assert().DateDiffGreaterThan(24, { absolute: true, asFloat: false, fromDate: new Date('1969-12-30 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-01 00:00:00'));
+    new Assert().DateDiffGreaterThan(24, { absolute: true, asFloat: false, fromDate: new Date('1969-12-30'), unit: 'hours' }).validate(new Date('1970-01-01'));
   });
 });

--- a/test/asserts/date-diff-greater-than-or-equal-to-assert_test.js
+++ b/test/asserts/date-diff-greater-than-or-equal-to-assert_test.js
@@ -98,7 +98,7 @@ describe('DateDiffGreaterThanOrEqualToAssert', () => {
 
   it('should throw an error if the diff between `fromDate` and input date is less than the `threshold`', () => {
     try {
-      new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { fromDate: new Date('1970-01-01 00:00:00') }).validate(new Date('1970-01-01 10:00:00'));
+      new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { fromDate: new Date('1970-01-01') }).validate(new Date('1970-01-01 10:00:00Z'));
 
       should.fail();
     } catch (e) {
@@ -156,7 +156,7 @@ describe('DateDiffGreaterThanOrEqualToAssert', () => {
 
   it('should use the `asFloat` option supplied', () => {
     try {
-      new Assert().DateDiffGreaterThanOrEqualTo(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00'), unit: 'minutes' }).validate(new Date('1970-01-01 10:04:51'));
+      new Assert().DateDiffGreaterThanOrEqualTo(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'minutes' }).validate(new Date('1970-01-01 10:04:51Z'));
 
       should.fail();
     } catch (e) {
@@ -167,7 +167,7 @@ describe('DateDiffGreaterThanOrEqualToAssert', () => {
 
   it('should use the `unit` option supplied', () => {
     try {
-      new Assert().DateDiffGreaterThanOrEqualTo(2000, { fromDate: new Date('1970-01-01 10:00:00'), unit: 'seconds' }).validate(new Date('1970-01-01 10:00:05'));
+      new Assert().DateDiffGreaterThanOrEqualTo(2000, { fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'seconds' }).validate(new Date('1970-01-01 10:00:05Z'));
 
       should.fail();
     } catch (e) {
@@ -178,7 +178,7 @@ describe('DateDiffGreaterThanOrEqualToAssert', () => {
   it('should accept a date whose diff from `now` is equal to the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31'));
 
     clock.restore();
   });
@@ -186,7 +186,7 @@ describe('DateDiffGreaterThanOrEqualToAssert', () => {
   it('should accept a date whose diff from `now` is greater than the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-30 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-30'));
 
     clock.restore();
   });
@@ -194,7 +194,7 @@ describe('DateDiffGreaterThanOrEqualToAssert', () => {
   it('should accept a date whose `absolute` diff from `now` is equal to the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-02 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-02'));
 
     clock.restore();
   });
@@ -202,24 +202,24 @@ describe('DateDiffGreaterThanOrEqualToAssert', () => {
   it('should accept a date whose `absolute` diff from `now` is greater than the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-03 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-03'));
 
     clock.restore();
   });
 
   it('should accept a date whose diff from `fromDate` is equal to the threshold', () => {
-    new Assert().DateDiffGreaterThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-31 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1969-12-31'));
   });
 
   it('should accept a date whose diff from `fromDate` is greater than the threshold', () => {
-    new Assert().DateDiffGreaterThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-30 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1969-12-30'));
   });
 
   it('should accept a date whose `absolute` diff from `fromDate` is equal to the threshold', () => {
-    new Assert().DateDiffGreaterThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-02 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1970-01-02'));
   });
 
   it('should accept a date whose `absolute` diff from `fromDate` is greater than the threshold', () => {
-    new Assert().DateDiffGreaterThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-03 00:00:00'));
+    new Assert().DateDiffGreaterThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1970-01-03'));
   });
 });

--- a/test/asserts/date-diff-less-than-assert_test.js
+++ b/test/asserts/date-diff-less-than-assert_test.js
@@ -234,7 +234,7 @@ describe('DateDiffLessThanAssert', () => {
 
   it('should use the `asFloat` option supplied', () => {
     try {
-      new Assert().DateDiffLessThan(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00'), unit: 'minutes' }).validate(new Date('1970-01-01 09:54:57'));
+      new Assert().DateDiffLessThan(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'minutes' }).validate(new Date('1970-01-01 09:54:57Z'));
 
       should.fail();
     } catch (e) {
@@ -244,18 +244,18 @@ describe('DateDiffLessThanAssert', () => {
   });
 
   it('should use the `unit` option supplied', () => {
-    new Assert().DateDiffLessThan(2000, { fromDate: new Date('1970-01-01 10:00:00'), unit: 'seconds' }).validate(new Date('1970-01-01 09:55:55'));
+    new Assert().DateDiffLessThan(2000, { fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'seconds' }).validate(new Date('1970-01-01 09:55:55Z'));
   });
 
   it('should accept a date whose diff from `now` is less than the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffLessThan(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 11:00:00'));
+    new Assert().DateDiffLessThan(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 11:00:00Z'));
 
     clock.restore();
   });
 
   it('should accept a date whose diff from `fromDate` is less than the threshold', () => {
-    new Assert().DateDiffLessThan(24, { asFloat: false, fromDate: new Date('1970-01-01 09:00:00'), unit: 'hours' }).validate(new Date('1970-01-01 00:00:00'));
+    new Assert().DateDiffLessThan(24, { asFloat: false, fromDate: new Date('1970-01-01 09:00:00Z'), unit: 'hours' }).validate(new Date('1970-01-01'));
   });
 });

--- a/test/asserts/date-diff-less-than-or-equal-to-assert_test.js
+++ b/test/asserts/date-diff-less-than-or-equal-to-assert_test.js
@@ -182,7 +182,7 @@ describe('DateDiffLessThanOrEqualToAssert', () => {
 
   it('should use the `asFloat` option supplied', () => {
     try {
-      new Assert().DateDiffLessThanOrEqualTo(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00'), unit: 'minutes' }).validate(new Date('1970-01-01 09:54:57'));
+      new Assert().DateDiffLessThanOrEqualTo(5, { asFloat: true, fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'minutes' }).validate(new Date('1970-01-01 09:54:57Z'));
 
       should.fail();
     } catch (e) {
@@ -192,13 +192,13 @@ describe('DateDiffLessThanOrEqualToAssert', () => {
   });
 
   it('should use the `unit` option supplied', () => {
-    new Assert().DateDiffLessThanOrEqualTo(2000, { fromDate: new Date('1970-01-01 10:00:00'), unit: 'seconds' }).validate(new Date('1970-01-01 09:55:55'));
+    new Assert().DateDiffLessThanOrEqualTo(2000, { fromDate: new Date('1970-01-01 10:00:00Z'), unit: 'seconds' }).validate(new Date('1970-01-01 09:55:55Z'));
   });
 
   it('should accept a date whose diff from `now` is equal to the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 00:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31'));
 
     clock.restore();
   });
@@ -206,7 +206,7 @@ describe('DateDiffLessThanOrEqualToAssert', () => {
   it('should accept a date whose diff from `now` is less than the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 11:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000).validate(new Date('1969-12-31 11:00:00Z'));
 
     clock.restore();
   });
@@ -214,7 +214,7 @@ describe('DateDiffLessThanOrEqualToAssert', () => {
   it('should accept a date whose `absolute` diff from `now` is equal to the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-02 00:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-02'));
 
     clock.restore();
   });
@@ -222,24 +222,24 @@ describe('DateDiffLessThanOrEqualToAssert', () => {
   it('should accept a date whose `absolute` diff from `now` is less than the threshold', () => {
     const clock = sinon.useFakeTimers(0, 'Date');
 
-    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-01 11:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24 * 60 * 60 * 1000, { absolute: true }).validate(new Date('1970-01-01 11:00:00Z'));
 
     clock.restore();
   });
 
   it('should accept a date whose diff from `fromDate` is equal to the threshold', () => {
-    new Assert().DateDiffLessThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-31 00:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1969-12-31'));
   });
 
   it('should accept a date whose diff from `fromDate` is less than the threshold', () => {
-    new Assert().DateDiffLessThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1969-12-31 11:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24, { asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1969-12-31 11:00:00Z'));
   });
 
   it('should accept a date whose `absolute` diff from `fromDate` is equal to the threshold', () => {
-    new Assert().DateDiffLessThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-02 00:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1970-01-02'));
   });
 
   it('should accept a date whose `absolute` diff from `fromDate` is less than the threshold', () => {
-    new Assert().DateDiffLessThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01 00:00:00'), unit: 'hours' }).validate(new Date('1970-01-01 11:00:00'));
+    new Assert().DateDiffLessThanOrEqualTo(24, { absolute: true, asFloat: false, fromDate: new Date('1970-01-01'), unit: 'hours' }).validate(new Date('1970-01-01 11:00:00Z'));
   });
 });


### PR DESCRIPTION
Resolves https://github.com/uphold/validator.js-asserts/issues/175.

This PR also adds support for node 10 on travis, to enforce a passing build from now on.