### PR TITLE
Fix Bank Identifier Code assert

### DIFF
--- a/src/asserts/bank-identifier-code-assert.js
+++ b/src/asserts/bank-identifier-code-assert.js
@@ -9,7 +9,7 @@ import { Validator, Violation } from 'validator.js';
  * Bic regex.
  */
 
-const bic = /^[a-zA-Z]{6}[a-zA-Z0-9]{2}([a-zA-Z0-9]{3})?$/;
+const bic = /^[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}$/i;
 
 /**
  * Export `BankIdentifierCodeAssert`.

--- a/test/asserts/bank-identifier-code-assert_test.js
+++ b/test/asserts/bank-identifier-code-assert_test.js
@@ -56,11 +56,31 @@ describe('BankIdentifierCodeAssert', () => {
     }
   });
 
+  it('should throw an error if the input value is not a valid bic', () => {
+    try {
+      new Assert().BankIdentifierCode().validate('BICOLETO');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.value.should.equal('BICOLETO');
+    }
+  });
+
   it('should accept a valid bic without branch code', () => {
     new Assert().BankIdentifierCode().validate('FOOBARBI');
   });
 
   it('should accept a valid bic with branch code', () => {
     new Assert().BankIdentifierCode().validate('FOOBARBIXXX');
+  });
+
+  it('should be case-insensitive', () => {
+    new Assert().BankIdentifierCode().validate('FOOBARBI');
+    new Assert().BankIdentifierCode().validate('FooBarBI');
+    new Assert().BankIdentifierCode().validate('foobarbi');
+    new Assert().BankIdentifierCode().validate('FOOBARBIXXX');
+    new Assert().BankIdentifierCode().validate('FooBarBIXXX');
+    new Assert().BankIdentifierCode().validate('foobarbixxx');
   });
 });


### PR DESCRIPTION
This PR fixes an issue with the BIC assert to match the _ISO-20022_ definition present in _CustomerCreditTransferInitiationV03_ [XSD schema](https://www.iso20022.org/documents/messages/1_0_version/pain/schemas/pain.001.001.03.zip):
```xml
<xs:simpleType name="BICIdentifier">
  <xs:restriction base="xs:string">
    <xs:pattern value="[A-Z]{6,6}[A-Z2-9][A-NP-Z0-9]([A-Z0-9]{3,3}){0,1}"/>
  </xs:restriction>
</xs:simpleType>
```

Currently, `BICOLETO` is one example of an invalid BIC which is passing the assert.

We are also keeping the assert case insensitive.