### PR TITLE
Add callback assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following set of extra asserts are provided by this package:
 - [BigNumberLessThan](#bignumberlessthan) (requires `bignumber.js`)
 - [BigNumberLessThanOrEqualTo](#bignumberlessthanorequalto) (requires `bignumber.js`)
 - [Boolean](#boolean)
+- [Callback](#callback) (requires `callback`)
 - [CreditCard](#creditcard) (requires `creditcard`)
 - [Date](#date) (requires `moment` for format validation only)
 - [DateDiffGreaterThan](#datediffgreaterthan) (requires `moment`)
@@ -94,6 +95,13 @@ Tests if a `BigNumber` is less than or equal to a given threshold.
 
 ### Boolean
 Tests if the value is a boolean.
+
+### Callback
+Allows you to add custom rules by giving a callback function and a custom class.
+
+#### Arguments
+- `callback` (required) - the callback function.
+- `customClass` (optional) - the name of the class.
 
 ### CreditCard
 Tests if the value is a valid credit card number using the Luhn10 algorithm.

--- a/src/asserts/callback-assert.js
+++ b/src/asserts/callback-assert.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const _ = require('lodash');
+const { Violation } = require('validator.js');
+
+/**
+ * Export `CallbackAssert`.
+ */
+
+module.exports = function(fn, customClass) {
+  /**
+   * Class name.
+   */
+
+  this.__class__ = customClass || 'Callback';
+
+  if (!_.isFunction(fn)) {
+    throw new Error('Callback must be instantiated with a function');
+  }
+
+  /**
+   * Fn.
+   */
+
+  this.fn = fn;
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = function(value) {
+    let result;
+
+    try {
+      result = this.fn(value);
+    } catch (error) {
+      throw new Violation(this, value, { error });
+    }
+
+    if (result !== true) {
+      throw new Violation(this, value, { result });
+    }
+
+    return true;
+  };
+
+  return this;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import BigNumberGreaterThanOrEqualTo from './asserts/big-number-greater-than-or-
 import BigNumberLessThan from './asserts/big-number-less-than-assert.js';
 import BigNumberLessThanOrEqualTo from './asserts/big-number-less-than-or-equal-to-assert.js';
 import Boolean from './asserts/boolean-assert.js';
+import Callback from './asserts/callback-assert';
 import CreditCard from './asserts/credit-card-assert.js';
 import Date from './asserts/date-assert.js';
 import DateDiffGreaterThan from './asserts/date-diff-greater-than-assert.js';
@@ -52,6 +53,7 @@ export default {
   BigNumberLessThan,
   BigNumberLessThanOrEqualTo,
   Boolean,
+  Callback,
   CreditCard,
   Date,
   DateDiffGreaterThan,

--- a/test/asserts/callback-assert.test.js
+++ b/test/asserts/callback-assert.test.js
@@ -1,0 +1,90 @@
+
+/**
+ * Module dependencies.
+ */
+
+import CallbackAssert from '../../src/asserts/callback-assert';
+import should from 'should';
+import { Assert as BaseAssert, Violation } from 'validator.js';
+
+/**
+ * Extend `Assert` with `CallbackAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  Callback: CallbackAssert
+});
+
+/**
+ * Test `CallbackAssert`.
+ */
+
+describe('CallbackAssert', () => {
+  it('should throw an error if `value` is missing', () => {
+    try {
+      Assert.callback().validate();
+
+      should.fail();
+    } catch (e) {
+      e.message.should.equal('Callback must be instantiated with a function');
+    }
+  });
+
+  it('should throw an error if `value` is not a function', () => {
+    try {
+      Assert.callback().validate('foobar');
+
+      should.fail();
+    } catch (e) {
+      e.message.should.equal('Callback must be instantiated with a function');
+    }
+  });
+
+  it('should throw an error if the given function is invalid', () => {
+    try {
+      // eslint-disable-next-line no-undef
+      Assert.callback(() => thisFunctionDoesNotExist()).validate('foobar');
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().assert.should.equal('Callback');
+      e.show().value.should.equal('foobar');
+      e.show().violation.should.not.be.undefined();
+      e.show().violation.error.should.be.instanceOf(ReferenceError);
+      e.show().violation.error.message.should.equal('thisFunctionDoesNotExist is not defined');
+    }
+  });
+
+  it('should throw an error if the callback function returns `false`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz').validate('foobar');
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().assert.should.equal('Callback');
+      e.show().value.should.equal('foobar');
+      e.show().violation.should.eql({ result: false });
+    }
+  });
+
+  it('should expose `assert` equal to `Callback`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz').validate('foobar');
+    } catch (e) {
+      e.show().assert.should.equal('Callback');
+    }
+  });
+
+  it('should have a `class` option and expose it as `assert`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz', 'CustomClass').validate('foobar');
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.show().assert.should.equal('CustomClass');
+      e.show().value.should.equal('foobar');
+      e.show().violation.should.eql({ result: false });
+    }
+  });
+
+  it('should not throw an error if the callback function returns `true`', () => {
+    Assert.callback(value => value === 'foobar').validate('foobar').should.be.true();
+  });
+});

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -21,6 +21,7 @@ describe('validator.js-asserts', () => {
       'BigNumberLessThan',
       'BigNumberLessThanOrEqualTo',
       'Boolean',
+      'Callback',
       'CreditCard',
       'Date',
       'DateDiffGreaterThan',


### PR DESCRIPTION
#### Description
Add callback assert.
This assert adds more context to the callback error as suggested by @franciscocardoso.

#### Steps to reproduce or test
When:

```
Assert.callback(() => {});
```

The error should be:
```
{
  "__class__": "Callback",
  "__parentClass__": "Assert"
}
```

Now when:
```
Assert.callback(() => {}, 'CustomClass');
```

```
{
  "__class__": "CustomClass",
  "__parentClass__": "Assert"
}
```

#### Checklist
- [ ] Commits are atomic and logically separated.
- [ ] Performance implications have been considered.
- [ ] Security implications have been considered.
- [ ] Local tests run successfully and the new code has good coverage.
