### PR TITLE
Add callback assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following set of extra asserts are provided by this package:
 - [BigNumberLessThan](#bignumberlessthan) (requires `bignumber.js`)
 - [BigNumberLessThanOrEqualTo](#bignumberlessthanorequalto) (requires `bignumber.js`)
 - [Boolean](#boolean)
+- [Callback](#callback) (requires `callback`)
 - [CreditCard](#creditcard) (requires `creditcard`)
 - [Date](#date) (requires `moment` for format validation only)
 - [DateDiffGreaterThan](#datediffgreaterthan) (requires `moment`)
@@ -96,6 +97,13 @@ Tests if a `BigNumber` is less than or equal to a given threshold.
 
 ### Boolean
 Tests if the value is a boolean.
+
+### Callback
+Allows you to add custom rules by giving a callback function and a custom class.
+
+#### Arguments
+- `callback` (required) - the callback function.
+- `customClass` (optional) - the name of the class.
 
 ### CreditCard
 Tests if the value is a valid credit card number using the Luhn10 algorithm.

--- a/src/asserts/callback-assert.js
+++ b/src/asserts/callback-assert.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const _ = require('lodash');
+const { Violation } = require('validator.js');
+
+/**
+ * Export `CallbackAssert`.
+ */
+
+module.exports = function(fn, customClass) {
+  /**
+   * Class name.
+   */
+
+  this.__class__ = customClass || 'Callback';
+
+  if (!_.isFunction(fn)) {
+    throw new Error('Callback must be instantiated with a function');
+  }
+
+  /**
+   * Fn.
+   */
+
+  this.fn = fn;
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = function(value) {
+    let result;
+
+    try {
+      result = this.fn(value);
+    } catch (error) {
+      throw new Violation(this, value, { error });
+    }
+
+    if (result !== true) {
+      throw new Violation(this, value, { result });
+    }
+
+    return true;
+  };
+
+  return this;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const BigNumberGreaterThanOrEqualTo = require('./asserts/big-number-greater-than
 const BigNumberLessThan = require('./asserts/big-number-less-than-assert.js');
 const BigNumberLessThanOrEqualTo = require('./asserts/big-number-less-than-or-equal-to-assert.js');
 const Boolean = require('./asserts/boolean-assert.js');
+const Callback = require('./asserts/callback-assert');
 const CreditCard = require('./asserts/credit-card-assert.js');
 const Date = require('./asserts/date-assert.js');
 const DateDiffGreaterThan = require('./asserts/date-diff-greater-than-assert.js');
@@ -53,6 +54,7 @@ module.exports = {
   BigNumberLessThan,
   BigNumberLessThanOrEqualTo,
   Boolean,
+  Callback,
   CreditCard,
   Date,
   DateDiffGreaterThan,

--- a/test/asserts/callback-assert.test.js
+++ b/test/asserts/callback-assert.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { Assert: BaseAssert, Violation } = require('validator.js');
+const CallbackAssert = require('../../src/asserts/callback-assert');
+
+/**
+ * Extend `Assert` with `CallbackAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  Callback: CallbackAssert
+});
+
+/**
+ * Test `CallbackAssert`.
+ */
+
+describe('CallbackAssert', () => {
+  it('should throw an error if `value` is missing', () => {
+    try {
+      Assert.callback().validate();
+
+      fail();
+    } catch (e) {
+      expect(e.message).toEqual('Callback must be instantiated with a function');
+    }
+  });
+
+  it('should throw an error if `value` is not a function', () => {
+    try {
+      Assert.callback().validate('foobar');
+
+      fail();
+    } catch (e) {
+      expect(e.message).toEqual('Callback must be instantiated with a function');
+    }
+  });
+
+  it('should throw an error if the given function is invalid', () => {
+    try {
+      // eslint-disable-next-line no-undef
+      Assert.callback(() => thisFunctionDoesNotExist()).validate('foobar');
+    } catch (e) {
+      expect(e).toBeInstanceOf(Violation);
+      expect(e.show().assert).toEqual('Callback');
+      expect(e.show().value).toEqual('foobar');
+      expect(e.show().violation).not.toBeUndefined();
+      expect(e.show().violation.error).toBeInstanceOf(ReferenceError);
+      expect(e.show().violation.error.message).toEqual('thisFunctionDoesNotExist is not defined');
+    }
+  });
+
+  it('should throw an error if the callback function returns `false`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz').validate('foobar');
+    } catch (e) {
+      expect(e).toBeInstanceOf(Violation);
+      expect(e.show().assert).toEqual('Callback');
+      expect(e.show().value).toEqual('foobar');
+      expect(e.show().violation.result).toBeFalsy();
+    }
+  });
+
+  it('should expose `assert` equal to `Callback`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz').validate('foobar');
+    } catch (e) {
+      expect(e.show().assert).toEqual('Callback');
+    }
+  });
+
+  it('should have a `class` option and expose it as `assert`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz', 'CustomClass').validate('foobar');
+    } catch (e) {
+      expect(e).toBeInstanceOf(Violation);
+      expect(e.show().assert).toEqual('CustomClass');
+      expect(e.show().value).toEqual('foobar');
+      expect(e.show().violation.result).toBeFalsy();
+    }
+  });
+
+  it('should not throw an error if the callback function returns `true`', () => {
+    Assert.callback(value => value === 'foobar').validate('foobar');
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ describe('validator.js-asserts', () => {
   it('should export all asserts', () => {
     const assertNames = Object.keys(asserts);
 
-    expect(assertNames).toHaveLength(34);
+    expect(assertNames).toHaveLength(35);
     expect(assertNames).toEqual(
       expect.arrayContaining([
         'AbaRoutingNumber',
@@ -26,6 +26,7 @@ describe('validator.js-asserts', () => {
         'BigNumberLessThan',
         'BigNumberLessThanOrEqualTo',
         'Boolean',
+        'Callback',
         'CreditCard',
         'Date',
         'DateDiffGreaterThan',


### PR DESCRIPTION
#### Description
Add callback assert.
This assert adds more context to the callback error as suggested by @franciscocardoso.

#### Steps to reproduce or test
When:

```
Assert.callback(() => {});
```

The error should be:
```
{
  "__class__": "Callback",
  "__parentClass__": "Assert"
}
```

Now when:
```
Assert.callback(() => {}, 'CustomClass');
```

```
{
  "__class__": "CustomClass",
  "__parentClass__": "Assert"
}
```

#### Checklist
- [ ] Commits are atomic and logically separated.
- [ ] Performance implications have been considered.
- [ ] Security implications have been considered.
- [ ] Local tests run successfully and the new code has good coverage.
