### PR TITLE
Update BigNumber@9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "abavalidator": "^2.0.1",
-    "bignumber.js": "^8.0.2",
+    "bignumber.js": "^9.0.0",
     "creditcard": "^0.1.2",
     "eslint": "^6.5.1",
     "eslint-config-uphold": "^1.0.1",
@@ -65,7 +65,7 @@
   },
   "optionalPeerDependencies": {
     "abavalidator": ">=2 <3",
-    "bignumber.js": ">=7 <9",
+    "bignumber.js": ">=7 <=9.0.0",
     "creditcard": ">=0.0.1 <1.0.0",
     "google-libphonenumber": ">=1 <4",
     "iban": ">=0.0.6 <1.0.0",

--- a/src/asserts/big-number-equal-to-assert.js
+++ b/src/asserts/big-number-equal-to-assert.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
 
@@ -45,9 +46,9 @@ module.exports = function bigNumberEqualToAssert(value, { validateSignificantDig
    */
 
   this.validate = value => {
-    Assert.bigNumber({ validateSignificantDigits }).validate(value);
-
     try {
+      Assert.bigNumber({ validateSignificantDigits }).validate(value);
+
       const number = new BigNumber(value);
 
       if (!number.isEqualTo(this.value)) {
@@ -55,9 +56,10 @@ module.exports = function bigNumberEqualToAssert(value, { validateSignificantDig
       }
     } catch (e) {
       const context = { value: this.value.toString() };
+      const message = e.message || _.get(e, 'violation.message');
 
-      if (e.message.startsWith('[BigNumber Error]')) {
-        context.message = e.message;
+      if (message && message.startsWith('[BigNumber Error]')) {
+        context.message = message;
       }
 
       throw new Violation(this, value, context);

--- a/src/asserts/big-number-greater-than-assert.js
+++ b/src/asserts/big-number-greater-than-assert.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
 
@@ -45,9 +46,9 @@ module.exports = function bigNumberGreaterThanAssert(threshold, { validateSignif
    */
 
   this.validate = value => {
-    Assert.bigNumber({ validateSignificantDigits }).validate(value);
-
     try {
+      Assert.bigNumber({ validateSignificantDigits }).validate(value);
+
       const number = new BigNumber(value);
 
       if (!number.isGreaterThan(this.threshold)) {
@@ -55,9 +56,10 @@ module.exports = function bigNumberGreaterThanAssert(threshold, { validateSignif
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
+      const message = e.message || _.get(e, 'violation.message');
 
-      if (e.message.startsWith('[BigNumber Error]')) {
-        context.message = e.message;
+      if (message && message.startsWith('[BigNumber Error]')) {
+        context.message = message;
       }
 
       throw new Violation(this, value, context);

--- a/src/asserts/big-number-greater-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-greater-than-or-equal-to-assert.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
 
@@ -37,7 +38,6 @@ module.exports = function bigNumberGreaterThanOrEqualToAssert(threshold, { valid
   }
 
   Assert.bigNumber({ validateSignificantDigits }).validate(threshold);
-
   this.threshold = new BigNumber(threshold);
 
   /**
@@ -45,9 +45,9 @@ module.exports = function bigNumberGreaterThanOrEqualToAssert(threshold, { valid
    */
 
   this.validate = value => {
-    Assert.bigNumber({ validateSignificantDigits }).validate(value);
-
     try {
+      Assert.bigNumber({ validateSignificantDigits }).validate(value);
+
       const number = new BigNumber(value);
 
       if (!number.isGreaterThanOrEqualTo(this.threshold)) {
@@ -55,9 +55,10 @@ module.exports = function bigNumberGreaterThanOrEqualToAssert(threshold, { valid
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
+      const message = e.message || _.get(e, 'violation.message');
 
-      if (e.message.startsWith('[BigNumber Error]')) {
-        context.message = e.message;
+      if (message && message.startsWith('[BigNumber Error]')) {
+        context.message = message;
       }
 
       throw new Violation(this, value, context);

--- a/src/asserts/big-number-less-than-assert.js
+++ b/src/asserts/big-number-less-than-assert.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
 
@@ -45,9 +46,9 @@ module.exports = function bigNumberLessThan(threshold, { validateSignificantDigi
    */
 
   this.validate = value => {
-    Assert.bigNumber({ validateSignificantDigits }).validate(value);
-
     try {
+      Assert.bigNumber({ validateSignificantDigits }).validate(value);
+
       const number = new BigNumber(value);
 
       if (!number.isLessThan(this.threshold)) {
@@ -55,9 +56,10 @@ module.exports = function bigNumberLessThan(threshold, { validateSignificantDigi
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
+      const message = e.message || _.get(e, 'violation.message');
 
-      if (e.message.startsWith('[BigNumber Error]')) {
-        context.message = e.message;
+      if (message && message.startsWith('[BigNumber Error]')) {
+        context.message = message;
       }
 
       throw new Violation(this, value, context);

--- a/src/asserts/big-number-less-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-less-than-or-equal-to-assert.js
@@ -4,6 +4,7 @@
  * Module dependencies.
  */
 
+const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
 
@@ -45,9 +46,9 @@ module.exports = function bigNumberLessThanOrEqualToAssert(threshold, { validate
    */
 
   this.validate = value => {
-    Assert.bigNumber({ validateSignificantDigits }).validate(value);
-
     try {
+      Assert.bigNumber({ validateSignificantDigits }).validate(value);
+
       const number = new BigNumber(value);
 
       if (!number.isLessThanOrEqualTo(this.threshold)) {
@@ -55,9 +56,10 @@ module.exports = function bigNumberLessThanOrEqualToAssert(threshold, { validate
       }
     } catch (e) {
       const context = { threshold: this.threshold.toString() };
+      const message = e.message || _.get(e, 'violation.message');
 
-      if (e.message.startsWith('[BigNumber Error]')) {
-        context.message = e.message;
+      if (message && message.startsWith('[BigNumber Error]')) {
+        context.message = message;
       }
 
       throw new Violation(this, value, context);

--- a/test/asserts/big-number-equal-to-assert.test.js
+++ b/test/asserts/big-number-equal-to-assert.test.js
@@ -90,12 +90,13 @@ describe('BigNumberEqualToAssert', () => {
         }
       });
 
-      it('should expose `message` on the violation if the input value is not a number', () => {
+      it('should expose `assert` equal to `BigNumberEqualTo` and `message` on the violation if the input value is not a number', () => {
         try {
           Assert.bigNumberEqualTo(10, option).validate({});
 
           fail();
         } catch (e) {
+          expect(e.show().assert).toBe('BigNumberEqualTo');
           expect(e.show().violation.message).toMatch(/Not a number/);
         }
       });

--- a/test/asserts/big-number-greater-than-assert.test.js
+++ b/test/asserts/big-number-greater-than-assert.test.js
@@ -90,12 +90,13 @@ describe('BigNumberGreaterThanAssert', () => {
         }
       });
 
-      it('should expose `message` on the violation if the input value is not a number', () => {
+      it('should expose `assert` equal to `BigNumberGreaterThan` and `message` on the violation if the input value is not a number', () => {
         try {
           Assert.bigNumberGreaterThan(10, option).validate({});
 
           fail();
         } catch (e) {
+          expect(e.show().assert).toBe('BigNumberGreaterThan');
           expect(e.show().violation.message).toMatch(/Not a number/);
         }
       });

--- a/test/asserts/big-number-greater-than-or-equal-to-assert.test.js
+++ b/test/asserts/big-number-greater-than-or-equal-to-assert.test.js
@@ -80,12 +80,13 @@ describe('BigNumberGreaterThanOrEqualToAssert', () => {
         }
       });
 
-      it('should expose `message` on the violation if the input value is not a number', () => {
+      it('should expose `assert` equal to `BigNumberGreaterThanOrEqualTo` and `message` on the violation if the input value is not a number', () => {
         try {
           Assert.bigNumberGreaterThanOrEqualTo(10, option).validate({});
 
           fail();
         } catch (e) {
+          expect(e.show().assert).toBe('BigNumberGreaterThanOrEqualTo');
           expect(e.show().violation.message).toMatch(/Not a number/);
         }
       });

--- a/test/asserts/big-number-less-than-assert.test.js
+++ b/test/asserts/big-number-less-than-assert.test.js
@@ -90,12 +90,13 @@ describe('BigNumberLessThanAssert', () => {
         }
       });
 
-      it('should expose `message` on the violation if the input value is not a number', () => {
+      it('should expose `assert` equal to `BigNumberLessThan` and `message` on the violation if the input value is not a number', () => {
         try {
           Assert.bigNumberLessThan(10, option).validate({});
 
           fail();
         } catch (e) {
+          expect(e.show().assert).toBe('BigNumberLessThan');
           expect(e.show().violation.message).toMatch(/Not a number/);
         }
       });

--- a/test/asserts/big-number-less-than-or-equal-to-assert.test.js
+++ b/test/asserts/big-number-less-than-or-equal-to-assert.test.js
@@ -80,12 +80,13 @@ describe('BigNumberLessThanOrEqualToAssert', () => {
         }
       });
 
-      it('should expose `message` on the violation if the input value is not a number', () => {
+      it('should expose `assert` equal to `BigNumberLessThanOrEqualTo` and `message` on the violation if the input value is not a number', () => {
         try {
           Assert.bigNumberLessThanOrEqualTo(10, option).validate({});
 
           fail();
         } catch (e) {
+          expect(e.show().assert).toBe('BigNumberLessThanOrEqualTo');
           expect(e.show().violation.message).toMatch(/Not a number/);
         }
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,10 +616,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bignumber.js@^8.0.2:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
-  integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This PR updates BigNumber to version 9.0.0.

In addition, this PR also fixes an issue where errors were being incorrecly thrown, i.e.:

`Assert.bigNumberGreaterThan(10, option).validate({});` 
 - before this commit, the thrown error/assert was `BigNumber`;
 - in this commit, the thrown error/assert is now `BigNumberGreaterThan`, as expected.

#### Related issues:
[PLAT-398](https://uphold.atlassian.net/browse/PLAT-398)