### PR TITLE
Improve callback assert to ensure an error class

### DIFF
--- a/src/asserts/callback-assert.js
+++ b/src/asserts/callback-assert.js
@@ -16,15 +16,19 @@ module.exports = function(fn, customClass) {
    * Class name.
    */
 
-  this.__class__ = customClass || 'Callback';
-
-  if (!_.isFunction(fn)) {
-    throw new Error('Callback must be instantiated with a function');
+  if (_.isNil(customClass)) {
+    throw new Error('Callback must be instantiated with a custom class');
   }
+
+  this.__class__ = customClass;
 
   /**
    * Fn.
    */
+
+  if (!_.isFunction(fn)) {
+    throw new Error('Callback must be instantiated with a function');
+  }
 
   this.fn = fn;
 

--- a/test/asserts/callback-assert.test.js
+++ b/test/asserts/callback-assert.test.js
@@ -20,9 +20,25 @@ const Assert = BaseAssert.extend({
  */
 
 describe('CallbackAssert', () => {
+  it('should fail if `customClass` is missing', () => {
+    try {
+      Assert.callback(value => value === 'foobiz').validate('foobar');
+    } catch (e) {
+      expect(e.message).toEqual('Callback must be instantiated with a custom class');
+    }
+  });
+
+  it('should fail if `customClass` is `null`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz', null).validate('foobar');
+    } catch (e) {
+      expect(e.message).toEqual('Callback must be instantiated with a custom class');
+    }
+  });
+
   it('should throw an error if `value` is missing', () => {
     try {
-      Assert.callback().validate();
+      Assert.callback(null, 'CustomClass').validate();
 
       fail();
     } catch (e) {
@@ -32,7 +48,7 @@ describe('CallbackAssert', () => {
 
   it('should throw an error if `value` is not a function', () => {
     try {
-      Assert.callback().validate('foobar');
+      Assert.callback(null, 'CustomClass').validate('foobar');
 
       fail();
     } catch (e) {
@@ -43,10 +59,10 @@ describe('CallbackAssert', () => {
   it('should throw an error if the given function is invalid', () => {
     try {
       // eslint-disable-next-line no-undef
-      Assert.callback(() => thisFunctionDoesNotExist()).validate('foobar');
+      Assert.callback(() => thisFunctionDoesNotExist(), 'CustomClass').validate('foobar');
     } catch (e) {
       expect(e).toBeInstanceOf(Violation);
-      expect(e.show().assert).toEqual('Callback');
+      expect(e.show().assert).toEqual('CustomClass');
       expect(e.show().value).toEqual('foobar');
       expect(e.show().violation).not.toBeUndefined();
       expect(e.show().violation.error).toBeInstanceOf(ReferenceError);
@@ -55,25 +71,6 @@ describe('CallbackAssert', () => {
   });
 
   it('should throw an error if the callback function returns `false`', () => {
-    try {
-      Assert.callback(value => value === 'foobiz').validate('foobar');
-    } catch (e) {
-      expect(e).toBeInstanceOf(Violation);
-      expect(e.show().assert).toEqual('Callback');
-      expect(e.show().value).toEqual('foobar');
-      expect(e.show().violation.result).toBeFalsy();
-    }
-  });
-
-  it('should expose `assert` equal to `Callback`', () => {
-    try {
-      Assert.callback(value => value === 'foobiz').validate('foobar');
-    } catch (e) {
-      expect(e.show().assert).toEqual('Callback');
-    }
-  });
-
-  it('should have a `class` option and expose it as `assert`', () => {
     try {
       Assert.callback(value => value === 'foobiz', 'CustomClass').validate('foobar');
     } catch (e) {
@@ -84,7 +81,15 @@ describe('CallbackAssert', () => {
     }
   });
 
+  it('should expose `assert` equal to `CustomClass`', () => {
+    try {
+      Assert.callback(value => value === 'foobiz', 'CustomClass').validate('foobar');
+    } catch (e) {
+      expect(e.show().assert).toEqual('CustomClass');
+    }
+  });
+
   it('should not throw an error if the callback function returns `true`', () => {
-    Assert.callback(value => value === 'foobar').validate('foobar');
+    Assert.callback(value => value === 'foobar', 'CustomClass').validate('foobar');
   });
 });


### PR DESCRIPTION
#### Description
This PR prevents the usage of the Callback assert without a custom class that will improve the understanding of the raised errors.

#### Related issues
[PLAT-517](https://uphold.atlassian.net/browse/PLAT-517)

#### Impacted areas
- Every app that use callback without a custom error class.

#### Deploy notes
Breaking changes so it is needed to increment the major version.