### PR TITLE
Improve optional dependency performance

### DIFF
--- a/src/asserts/aba-routing-number-assert.js
+++ b/src/asserts/aba-routing-number-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Validator, Violation } = require('validator.js');
+let abaValidator;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  abaValidator = require('abavalidator');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `AbaRoutingNumberAssert`.
  */
 
 module.exports = function abaRoutingNumberAssert() {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const abaValidator = require('abavalidator');
+  if (!abaValidator) {
+    throw new Error('abaValidator is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/big-number-assert.js
+++ b/src/asserts/big-number-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Violation } = require('validator.js');
+let BigNumber;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  BigNumber = require('bignumber.js');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `BigNumberAssert`.
  */
 
 module.exports = function bigNumberAssert({ validateSignificantDigits = true } = {}) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const BigNumber = require('bignumber.js');
+  if (!BigNumber) {
+    throw new Error('BigNumber is not installed');
+  }
 
   BigNumber.DEBUG = !!validateSignificantDigits;
 

--- a/src/asserts/big-number-equal-to-assert.js
+++ b/src/asserts/big-number-equal-to-assert.js
@@ -7,17 +7,26 @@
 const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
+let BigNumber;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  BigNumber = require('bignumber.js');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `BigNumberEqualToAssert`.
  */
 
 module.exports = function bigNumberEqualToAssert(value, { validateSignificantDigits = true } = {}) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const BigNumber = require('bignumber.js');
+  if (!BigNumber) {
+    throw new Error('BigNumber is not installed');
+  }
 
   BigNumber.DEBUG = !!validateSignificantDigits;
 

--- a/src/asserts/big-number-greater-than-assert.js
+++ b/src/asserts/big-number-greater-than-assert.js
@@ -7,17 +7,26 @@
 const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
+let BigNumber;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  BigNumber = require('bignumber.js');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `BigNumberGreaterThanAssert`.
  */
 
 module.exports = function bigNumberGreaterThanAssert(threshold, { validateSignificantDigits = true } = {}) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const BigNumber = require('bignumber.js');
+  if (!BigNumber) {
+    throw new Error('BigNumber is not installed');
+  }
 
   BigNumber.DEBUG = !!validateSignificantDigits;
 

--- a/src/asserts/big-number-greater-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-greater-than-or-equal-to-assert.js
@@ -7,17 +7,26 @@
 const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
+let BigNumber;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  BigNumber = require('bignumber.js');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `BigNumberGreaterThanOrEqualToAssert`.
  */
 
 module.exports = function bigNumberGreaterThanOrEqualToAssert(threshold, { validateSignificantDigits = true } = {}) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const BigNumber = require('bignumber.js');
+  if (!BigNumber) {
+    throw new Error('BigNumber is not installed');
+  }
 
   BigNumber.DEBUG = !!validateSignificantDigits;
 

--- a/src/asserts/big-number-less-than-assert.js
+++ b/src/asserts/big-number-less-than-assert.js
@@ -7,17 +7,26 @@
 const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
+let BigNumber;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  BigNumber = require('bignumber.js');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `BigNumberLessThan`.
  */
 
 module.exports = function bigNumberLessThan(threshold, { validateSignificantDigits = true } = {}) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const BigNumber = require('bignumber.js');
+  if (!BigNumber) {
+    throw new Error('BigNumber is not installed');
+  }
 
   BigNumber.DEBUG = !!validateSignificantDigits;
 

--- a/src/asserts/big-number-less-than-or-equal-to-assert.js
+++ b/src/asserts/big-number-less-than-or-equal-to-assert.js
@@ -7,17 +7,26 @@
 const _ = require('lodash');
 const { Assert: BaseAssert, Violation } = require('validator.js');
 const BigNumberAssert = require('./big-number-assert');
+let BigNumber;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  BigNumber = require('bignumber.js');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `BigNumberLessThanOrEqualToAssert`.
  */
 
 module.exports = function bigNumberLessThanOrEqualToAssert(threshold, { validateSignificantDigits = true } = {}) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const BigNumber = require('bignumber.js');
+  if (!BigNumber) {
+    throw new Error('BigNumber is not installed');
+  }
 
   BigNumber.DEBUG = !!validateSignificantDigits;
 

--- a/src/asserts/credit-card-assert.js
+++ b/src/asserts/credit-card-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Violation } = require('validator.js');
+let creditcard;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  creditcard = require('creditcard');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `CreditCardAssert`.
  */
 
 module.exports = function creditCardAssert() {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const creditcard = require('creditcard');
+  if (!creditcard) {
+    throw new Error('creditcard is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/date-assert.js
+++ b/src/asserts/date-assert.js
@@ -5,6 +5,17 @@
  */
 
 const { Violation } = require('validator.js');
+let moment;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  moment = require('moment');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `DateAssert`.
@@ -18,17 +29,13 @@ module.exports = function dateAssert({ format } = {}) {
   this.__class__ = 'Date';
 
   /**
-   * Optional peer dependency.
-   */
-
-  let moment;
-
-  /**
    * Validate format.
    */
 
   if (format) {
-    moment = require('moment');
+    if (!moment) {
+      throw new Error('moment is not installed');
+    }
   }
 
   /**

--- a/src/asserts/date-diff-greater-than-assert.js
+++ b/src/asserts/date-diff-greater-than-assert.js
@@ -6,17 +6,26 @@
 
 const { Violation } = require('validator.js');
 const { assign } = require('lodash');
+let moment;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  moment = require('moment');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `DateDiffGreaterThanAssert`.
  */
 
 module.exports = function dateDiffGreaterThanAssert(threshold, options) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const moment = require('moment');
+  if (!moment) {
+    throw new Error('moment is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/date-diff-greater-than-or-equal-to-assert.js
+++ b/src/asserts/date-diff-greater-than-or-equal-to-assert.js
@@ -6,17 +6,26 @@
 
 const { Violation } = require('validator.js');
 const { assign } = require('lodash');
+let moment;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  moment = require('moment');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `DateDiffGreaterThanOrEqualToAssert`.
  */
 
 module.exports = function dateDiffGreaterThanOrEqualToAssert(threshold, options) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const moment = require('moment');
+  if (!moment) {
+    throw new Error('moment is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/date-diff-less-than-assert.js
+++ b/src/asserts/date-diff-less-than-assert.js
@@ -6,17 +6,26 @@
 
 const { Violation } = require('validator.js');
 const { assign } = require('lodash');
+let moment;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  moment = require('moment');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `DateDiffLessThanAssert`.
  */
 
 module.exports = function dateDiffLessThanAssert(threshold, options) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const moment = require('moment');
+  if (!moment) {
+    throw new Error('moment is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/date-diff-less-than-or-equal-to-assert.js
+++ b/src/asserts/date-diff-less-than-or-equal-to-assert.js
@@ -6,17 +6,26 @@
 
 const { Violation } = require('validator.js');
 const { assign } = require('lodash');
+let moment;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  moment = require('moment');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `DateDiffLessThanOrEqualToAssert`.
  */
 
 module.exports = function dateDiffLessThanOrEqualToAssert(threshold, options) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const moment = require('moment');
+  if (!moment) {
+    throw new Error('moment is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/email-assert.js
+++ b/src/asserts/email-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Assert: is, Validator, Violation } = require('validator.js');
+let validator;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  validator = require('validator');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `EmailAssert`.
  */
 
 module.exports = function emailAssert() {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const validator = require('validator');
+  if (!validator) {
+    throw new Error('validator is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/international-bank-account-number-assert.js
+++ b/src/asserts/international-bank-account-number-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Validator, Violation } = require('validator.js');
+let iban;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  iban = require('iban');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `InternationalBankAccountNumberAssert`.
  */
 
 module.exports = function internationalBankAccountNumberAssert() {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const iban = require('iban');
+  if (!iban) {
+    throw new Error('iban is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/iso-3166-country-assert.js
+++ b/src/asserts/iso-3166-country-assert.js
@@ -6,17 +6,26 @@
 
 const { Validator, Violation } = require('validator.js');
 const { find } = require('lodash');
+let countries;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  countries = require('isoc');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `Iso3166CountryAssert`.
  */
 
 module.exports = function iso3166CountryAssert() {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const countries = require('isoc');
+  if (!countries) {
+    throw new Error('isoc is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/phone-assert.js
+++ b/src/asserts/phone-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Validator, Violation } = require('validator.js');
+let PhoneNumberUtil;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  ({ PhoneNumberUtil } = require('google-libphonenumber'));
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `Phone`.
  */
 
 module.exports = function phoneAssert({ countryCode } = {}) {
-  /**
-   * Peer dependency `google-libphonenumber`.
-   */
-
-  const { PhoneNumberUtil } = require('google-libphonenumber');
+  if (!PhoneNumberUtil) {
+    throw new Error('google-libphonenumber is not installed');
+  }
 
   /**
    * Phone util instance.

--- a/src/asserts/taxpayer-identification-number-assert.js
+++ b/src/asserts/taxpayer-identification-number-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Validator, Violation } = require('validator.js');
+let tin;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  tin = require('tin-validator');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `TaxpayerIdentificationNumberAssert`.
  */
 
 module.exports = function taxpayerIdentificationNumberAssert() {
-  /**
-   * Optional peer dependency.
-   */
-
-  const tin = require('tin-validator');
+  if (!tin) {
+    throw new Error('tin-validator is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/uk-modulus-checking-assert.js
+++ b/src/asserts/uk-modulus-checking-assert.js
@@ -5,17 +5,26 @@
  */
 
 const { Validator, Violation } = require('validator.js');
+let UkModulusChecking;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  UkModulusChecking = require('uk-modulus-checking');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `UkModulusCheckingAssert`.
  */
 
 module.exports = function ukModulusCheckingAssert() {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const UkModulusChecking = require('uk-modulus-checking');
+  if (!UkModulusChecking) {
+    throw new Error('uk-modulus-checking is not installed');
+  }
 
   /**
    * Class name.

--- a/src/asserts/uri-assert.js
+++ b/src/asserts/uri-assert.js
@@ -6,17 +6,26 @@
 
 const { Validator, Violation } = require('validator.js');
 const { forEach, has } = require('lodash');
+let URI;
+
+/**
+ * Optional peer dependencies.
+ */
+
+try {
+  URI = require('urijs');
+} catch (e) {
+  // eslint-disable-next-line no-empty
+}
 
 /**
  * Export `UriAssert`.
  */
 
 module.exports = function uriAssert(constraints) {
-  /**
-   * Optional peer dependencies.
-   */
-
-  const URI = require('urijs');
+  if (!URI) {
+    throw new Error('urijs is not installed');
+  }
 
   /**
    * Class name.


### PR DESCRIPTION
Pulls optional dependencies out of the initialization function, to improve performance for callers that use a particular assert multiple times, **achieving a 3x speedup** 🚀  (on my machine™)

I used the following script to benchmark the change:

```js
const _ = require('lodash');
const { Assert: BaseAssert } = require('validator.js');
const Benchmark = require('benchmark');
const BigNumberAssert = require('../src/asserts/big-number-assert');
const BigNumberAssertOld = require('../src/asserts/big-number-assert-old');
const Assert = BaseAssert.extend({
  BigNumber: BigNumberAssert,
  BigNumberOld: BigNumberAssertOld
});

const suite = new Benchmark.Suite();

suite
  .add('BigNumber with implicit require (old)', function() {
    Assert.bigNumberOld().validate(_.random(1, 10000));
  })
  .add('BigNumber with conditional require (new)', function() {
    Assert.bigNumber().validate(_.random(1, 10000));
  })
  .on('cycle', function(event) {
    console.log(String(event.target));
  })
  .on('complete', function() {
    console.log(`Fastest is ${this.filter('fastest').map('name')}`);
  })
  .run({ async: true });

```

Output:

```
BigNumber with implicit require (old) x 1,773,128 ops/sec ±0.80% (85 runs sampled)
BigNumber with conditional require (new) x 3,932,949 ops/sec ±0.72% (87 runs sampled)
Fastest is BigNumber with conditional require (new)
```