### PR TITLE
Add `ObjectAssert` to assertions

### DIFF
--- a/src/asserts/plain-object-ts-assert.js
+++ b/src/asserts/plain-object-ts-assert.js
@@ -1,0 +1,30 @@
+const { Violation } = require('validator.js');
+const isPlainObject = require('lodash');
+
+/**
+ * Export `PlainObjectTSAssert`.
+ */
+
+module.exports = function plainObjectTSAssert() {
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'plainObjectTS';
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = value => {
+    const prototype = Object.getPrototypeOf(value);
+
+    if (!isPlainObject(prototype)) {
+      throw new Violation(this, value);
+    }
+
+    return true;
+  };
+
+  return this;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ const NullOrDate = require('./asserts/null-or-date-assert.js');
 const NullOrString = require('./asserts/null-or-string-assert.js');
 const Phone = require('./asserts/phone-assert.js');
 const PlainObject = require('./asserts/plain-object-assert.js');
+const PlainObjectTS = require('./asserts/plain-object-ts-assert.js');
 const TaxpayerIdentificationNumber = require('./asserts/taxpayer-identification-number-assert.js');
 const UkModulusChecking = require('./asserts/uk-modulus-checking-assert.js');
 const Uri = require('./asserts/uri-assert.js');
@@ -76,6 +77,7 @@ module.exports = {
   NullOrString,
   Phone,
   PlainObject,
+  PlainObjectTS,
   TaxpayerIdentificationNumber,
   UkModulusChecking,
   Uri,

--- a/test/asserts/plain-object-ts-assert.js
+++ b/test/asserts/plain-object-ts-assert.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { Assert: BaseAssert, Violation } = require('validator.js');
+const PlainObjectTSAssert = require('../../src/asserts/plain-object-ts-assert');
+
+/**
+ * Extend `Assert` with `PlainObjectTSAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  PlainObjectTS: PlainObjectTSAssert
+});
+
+/**
+ * Test `PlainObjectTSAssert`.
+ */
+
+describe('PlainObjectTSAssert', () => {
+  it(`should throw an error if the input value's prototype is not a plain object`, () => {
+    const choices = ['foobar', 123];
+
+    choices.forEach(choice => {
+      try {
+        Assert.plainObjectTS().validate(choice);
+
+        fail();
+      } catch (e) {
+        expect(e).toBeInstanceOf(Violation);
+      }
+    });
+  });
+
+  it('should expose `assert` equal to `plainObjectTS`', () => {
+    try {
+      Assert.plainObjectTS().validate('FOO');
+
+      fail();
+    } catch (e) {
+      expect(e.show().assert).toBe('PlainObjectTS');
+    }
+  });
+
+  it('should accept an object', () => {
+    const foo = Object.create(Object.prototype);
+
+    Assert.plainObjectTS().validate(foo);
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ describe('validator.js-asserts', () => {
   it('should export all asserts', () => {
     const assertNames = Object.keys(asserts);
 
-    expect(assertNames).toHaveLength(36);
+    expect(assertNames).toHaveLength(37);
     expect(assertNames).toEqual(
       expect.arrayContaining([
         'AbaRoutingNumber',
@@ -47,6 +47,7 @@ describe('validator.js-asserts', () => {
         'NullOrString',
         'Phone',
         'PlainObject',
+        'PlainObjectTS',
         'TaxpayerIdentificationNumber',
         'UkModulusChecking',
         'Uri',


### PR DESCRIPTION
The existing assert `PlainObjectAssert` was not working for objects of type `Record<string, unknown>`, which TypeScript suggests to use over type `object`. This new assertion will validate that a value is an object (excludes functions), while having less restrictions compared to `PlainObjectAssert`. Here is a code snippet of lodash's isPlainObject() method and why less restrictions were needed when dealing with types such as `Record<string, unknown>.`

```js
function isPlainObject(value) {
  var Ctor;
  if (!(isObjectLike(value) && objToString.call(value) == objectTag && !isHostObject(value) && !isArguments(value)) ||
      (!hasOwnProperty.call(value, 'constructor') && (Ctor = value.constructor, typeof Ctor == 'function' && !(Ctor instanceof Ctor)))) {
    return false;
  }
  var result;
  if (lodash.support.ownLast) {
    baseForIn(value, function(subValue, key, object) {
      result = hasOwnProperty.call(object, key);
      return false;
    });
    return result !== false;
  }
  baseForIn(value, function(subValue, key) {
    result = key;
  });
  return result === undefined || hasOwnProperty.call(value, result);
}
```