### PR TITLE
Add support for numbers to be in callback assert custom class

### DIFF
--- a/src/asserts/callback-assert.js
+++ b/src/asserts/callback-assert.js
@@ -11,7 +11,7 @@ const { Violation } = require('validator.js');
  * Constants.
  */
 
-const expression = /^[a-zA-Z]+$/;
+const expression = /^[a-zA-Z\d]+$/;
 
 /**
  * Export `CallbackAssert`.

--- a/test/asserts/callback-assert.test.js
+++ b/test/asserts/callback-assert.test.js
@@ -29,7 +29,7 @@ describe('CallbackAssert', () => {
   });
 
   it('should throw an error if `customClass` is invalid', () => {
-    ['foo bar', 'foo 1', '1', '{}', 1].forEach(customClass => {
+    ['foo bar', 'foo 1', '%', '{}'].forEach(customClass => {
       try {
         Assert.callback(value => value === 'foobiz', customClass).validate('foobar');
       } catch (e) {


### PR DESCRIPTION
I updated the test regex in the callback assert to allow custom error's with numbers, such as `CardNot3DSecure3DSEnabled`. 