### PR TITLE
Add `nullOrUuid` assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following set of extra asserts are provided by this package:
 - [NullOrDate](#nullordate)
 - [NullOrBoolean](#nullorboolean)
 - [NullOrString](#nullorstring)
+- [NullOrUuid](#nulloruuid)
 - [Phone](#phone) (requires `google-libphonenumber`)
 - [PlainObject](#plainobject)
 - [TaxpayerIdentificationNumber](#taxpayeridentificationnumber) (_TIN_, requires `tin-validator`)
@@ -201,6 +202,9 @@ Tests if the value is a `null` or `boolean`.
 
 ### NullOrString
 Tests if the value is a `null` or `string`, optionally within some boundaries.
+
+### NullOrUuid
+Tests if the value is a `null` or `uuid`.
 
 #### Arguments
 - `boundaries` (optional) - `max` and/or `min` boundaries to test the string for.

--- a/src/asserts/null-or-uuid-assert.js
+++ b/src/asserts/null-or-uuid-assert.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { Assert: BaseAssert, Violation } = require('validator.js');
+const UuidAssert = require('./uuid-assert');
+
+/**
+ * Export `NullOrUuidAssert`.
+ */
+
+module.exports = function nullOrUuidAssert(version) {
+  /**
+   * Extend `Assert` with `UuidAssert`.
+   */
+
+  const Assert = BaseAssert.extend({ Uuid: UuidAssert });
+  /**
+   * Class name.
+   */
+
+  this.__class__ = 'NullOrUuid';
+
+  /**
+   * Uuid version.
+   */
+
+  this.version = version;
+
+  /**
+   * Validation algorithm.
+   */
+
+  this.validate = value => {
+    if (value !== null && typeof value !== 'string') {
+      throw new Violation(this, value, { value: 'must_be_null_or_an_uuid' });
+    }
+
+    if (value === null) {
+      return true;
+    }
+
+    try {
+      Assert.uuid(this.version).validate(value);
+    } catch (e) {
+      throw new Violation(this, value, e.violation);
+    }
+
+    return true;
+  };
+
+  return this;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ const NotEmpty = require('./asserts/not-empty-assert.js');
 const NullOrBoolean = require('./asserts/null-or-boolean-assert.js');
 const NullOrDate = require('./asserts/null-or-date-assert.js');
 const NullOrString = require('./asserts/null-or-string-assert.js');
+const NullOrUuid = require('./asserts/null-or-uuid-assert.js');
 const Phone = require('./asserts/phone-assert.js');
 const PlainObject = require('./asserts/plain-object-assert.js');
 const TaxpayerIdentificationNumber = require('./asserts/taxpayer-identification-number-assert.js');
@@ -76,6 +77,7 @@ module.exports = {
   NullOrBoolean,
   NullOrDate,
   NullOrString,
+  NullOrUuid,
   Phone,
   PlainObject,
   TaxpayerIdentificationNumber,

--- a/test/asserts/null-or-uuid-assert.test.js
+++ b/test/asserts/null-or-uuid-assert.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { Assert: BaseAssert, Violation } = require('validator.js');
+const NullOrUuidAssert = require('../../src/asserts/null-or-uuid-assert');
+
+/**
+ * Extend `Assert` with `NullOrUuidAssert`.
+ */
+
+const Assert = BaseAssert.extend({
+  NullOrUuid: NullOrUuidAssert
+});
+
+/**
+ * Test `NullOrUuidAssert`.
+ */
+
+describe('NullOrUuidAssert', () => {
+  it('should throw an error if the input value is not a `null` or a string', () => {
+    const choices = [[], {}, 123, new Boolean(true)]; // eslint-disable-line no-new-wrappers
+
+    choices.forEach(choice => {
+      try {
+        Assert.nullOrUuid().validate(choice);
+
+        fail();
+      } catch (e) {
+        expect(e).toBeInstanceOf(Violation);
+        expect(e.violation.value).toBe('must_be_null_or_an_uuid');
+      }
+    });
+  });
+
+  it('should expose `assert` equal to `NullOrUuid`', () => {
+    try {
+      Assert.nullOrUuid().validate({});
+
+      fail();
+    } catch (e) {
+      expect(e.show().assert).toBe('NullOrUuid');
+    }
+  });
+
+  it('should expose `version` on the violation', () => {
+    try {
+      Assert.nullOrUuid(3).validate('d1885a73-9437-5fde-97e0-8074dc5b6c88');
+
+      fail();
+    } catch (e) {
+      expect(e.show().violation.version).toBe(3);
+    }
+  });
+
+  it('should accept `null`', () => {
+    Assert.nullOrUuid().validate(null);
+  });
+
+  it('should accept a v3 uuid value', () => {
+    Assert.nullOrUuid(3).validate('6fa459ea-ee8a-3ca4-894e-db77e160355e');
+  });
+
+  it('should accept a v4 uuid value', () => {
+    Assert.nullOrUuid(4).validate('340b4140-5439-4fef-b45e-dc4ea23d1b2a');
+  });
+
+  it('should accept a v5 uuid value', () => {
+    Assert.nullOrUuid(5).validate('d1885a73-9437-5fde-97e0-8074dc5b6c88');
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ describe('validator.js-asserts', () => {
   it('should export all asserts', () => {
     const assertNames = Object.keys(asserts);
 
-    expect(assertNames).toHaveLength(37);
+    expect(assertNames).toHaveLength(38);
     expect(assertNames).toEqual(
       expect.arrayContaining([
         'AbaRoutingNumber',
@@ -46,6 +46,7 @@ describe('validator.js-asserts', () => {
         'NullOrBoolean',
         'NullOrDate',
         'NullOrString',
+        'NullOrUuid',
         'Phone',
         'PlainObject',
         'TaxpayerIdentificationNumber',


### PR DESCRIPTION
## Description

This PR adds a `nullOrUuid` assert that allows validation of nullable UUID values.