### PR TITLE
Add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, they will
+# be requested for review when someone opens a pull request.
+
+* @uphold/engineering-leadership @uphold/core-backend-codeowners @uphold/backoffice-backend-codeowners @uphold/crypto-backend-codeowners @uphold/digital-payments-backend-codeowners @uphold/payments-backend-codeowners @uphold/wallet-backend-codeowners
+
+# Order is important; the last matching pattern takes the most
+# precedence. Rules are not additive, meaning people or teams
+# defined above will not be considered codeowners of patterns
+# below unless explicitly added.
+
+/.github/CODEOWNERS @uphold/engineering-leadership


### PR DESCRIPTION
## Description

- Add `CODEOWNERS` for the repository to streamline the review process for pull requests. This addition specifies ownership for various teams and ensures proper review coverage.