### PR TITLE
Fix `peerDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ $ npm install --save validator.js-asserts
 ```
 
 ### Peer dependencies
+
 Some asserts require manually installing some _peer dependencies_. Failing to do so will result in runtime errors, as packages are required dynamically.
 
-Peer dependencies are not listed on `package.json` because npm 2 considers them _mandatory peer dependencies_ and, therefore, always installs them, while [npm 3](https://github.com/npm/npm/blob/master/CHANGELOG.md#peerdependencies) follows a more consensual approach of _optional peer dependencies_, not installing them by default but generating warning and confusing error messages instead.
-
-You should pin these package's peer dependencies to the ranges listed on the _optionalPeerDependencies_ key of this package's manifest.
+Peer dependencies are listed on `package.json` under `peerDependencies`.
+The `peerDependenciesMeta` key identifies which peer dependencies are optional. NPM will not automatically install optional peer dependencies. See [the NPM documentation](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta) for more information.
 
 ## Asserts
 The following set of extra asserts are provided by this package:

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "test:watch": "node --test --watch"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
-    "validator.js": "^2.0.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
@@ -62,7 +61,69 @@
     "uk-modulus-checking": "0.0.3",
     "urijs": "^1.17.1",
     "validate-rfc": "^2.0.3",
+    "validator.js": "^2.0.0",
     "validator": "^13.15.15"
+  },
+  "peerDependencies": {
+    "abavalidator": "^2.0.0",
+    "bignumber.js": ">=7 || <=9.3.0",
+    "cpf": "^2.0.1",
+    "creditcard": ">=0.0.1 <1.0.0",
+    "curp": "^1.2.3",
+    "google-libphonenumber": ">=1 <4",
+    "iban": ">=0.0.6 <1.0.0",
+    "isoc": ">=0.0.1 <1.0.0",
+    "moment": "^2.0.0",
+    "tin-validator": "^1.0.0",
+    "uk-modulus-checking": "^0.0.2",
+    "urijs": "^1.0.0",
+    "validate-rfc": "^2.0.3",
+    "validator.js": "^2.0.0",
+    "validator": ">=3 <14"
+  },
+  "peerDependenciesMeta": {
+    "abavalidator": {
+      "optional": true
+    },
+    "bignumber.js": {
+      "optional": true
+    },
+    "cpf": {
+      "optional": true
+    },
+    "creditcard": {
+      "optional": true
+    },
+    "curp": {
+      "optional": true
+    },
+    "google-libphonenumber": {
+      "optional": true
+    },
+    "iban": {
+      "optional": true
+    },
+    "isoc": {
+      "optional": true
+    },
+    "moment": {
+      "optional": true
+    },
+    "tin-validator": {
+      "optional": true
+    },
+    "uk-modulus-checking": {
+      "optional": true
+    },
+    "urijs": {
+      "optional": true
+    },
+    "validate-rfc": {
+      "optional": true
+    },
+    "validator": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Description

- Move `validator.js` to dev and peer dependency.
- Update invalid `optionalPeerDependencies` to `peerDependencies` and `peerDependenciesMeta`. See the following for documentation on `peerDependenciesMeta`:
  - `npm` https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta
  - `yarn` `v1`/classic https://classic.yarnpkg.com/en/docs/package-json#toc-peerdependenciesmeta
  - `yarn` `v4` https://yarnpkg.com/configuration/manifest#peerDependenciesMeta
  - `pnpm` https://pnpm.io/next/package_json#peerdependenciesmetaoptional

> [!WARNING]
> This is a breaking change, so it should be part of a major release